### PR TITLE
Add ERD & sequence diagrams

### DIFF
--- a/diagrams/post.createPost.sequenceDiagram.plantuml
+++ b/diagrams/post.createPost.sequenceDiagram.plantuml
@@ -1,0 +1,22 @@
+@startuml create_post
+hide footbox
+skinparam maxMessageSize 150
+actor user
+
+participant postService
+participant mediaService
+participant uploadService
+
+user -> postService : request to creat post 
+postService -> user : post id
+user -> postService : Request to create optionsGroup(s) and options
+postService -> user : optionsGroup(s) id + options ids
+user -> postService : binary file(s) 
+postService -> user : ack
+user -> postService : flag post as finished
+postService -> user : 204 response
+postService -> mediaService: Binary files
+mediaService -> uploadService: New binary files
+uploadService -> mediaService: Original URLs
+mediaService -> postService: Masked URLs
+@enduml

--- a/diagrams/post.database.plantuml
+++ b/diagrams/post.database.plantuml
@@ -1,0 +1,59 @@
+@startuml posts_database
+' hide the spot
+hide circle
+
+' avoid problems with angled crows feet
+skinparam linetype ortho
+
+entity "Post" as post {
+    *id : number <<generated>>
+    --
+    *caption: text
+    *type: text
+    *is_Hidden: text
+    *user_id: number <<FK>>
+    *ready: boolean
+    *created: boolean
+}
+
+entity "Media" as media {
+    *id : number <<generated>>
+    --
+    *post_id: number <<FK>>
+    *group_id: number <<FK>>
+    *option_id: number <<FK>>
+    *URL: text
+}
+
+entity "Group" as group {
+    *id : number <<generated>>
+    --
+    *post_id: number <<FK>>
+    *name : text
+}
+
+entity "Option" as option {
+    *id : number <<generated>>
+    --
+    'content column is just text content of the text options
+    'images are requested from media service by post id
+    *group_id : <<FK>>
+    *body : text
+    *vote_count : number
+}
+
+entity "Vote" as vote {
+    *id : number <<generated>>
+    --
+    *option_id: number <<FK>>
+    *user_id: number <<FK>>
+}
+
+post ||..|{ media
+post ||..|{ group
+group ||..|{ option
+option ||..|{ vote
+media ||..|| option
+media ||..|| group
+
+@enduml

--- a/diagrams/post.requestFeed.sequenceDiagram.plantuml
+++ b/diagrams/post.requestFeed.sequenceDiagram.plantuml
@@ -1,0 +1,18 @@
+@startuml
+hide footbox
+
+actor user
+
+participant postService
+participant mediaService
+participant provider
+
+user -> postService : Request Post
+postService -> user: Posts
+group Proxying
+user -> mediaService : Browser requests image blobs
+mediaService -> provider : Proxy image blobs from provider to the client
+provider -> mediaService : Original binary files
+mediaService -> user : Original binary files
+end
+@enduml

--- a/diagrams/post.vote.sequenceDiagram.plantuml
+++ b/diagrams/post.vote.sequenceDiagram.plantuml
@@ -1,0 +1,15 @@
+@startuml
+hide footbox
+
+actor endUser
+
+participant postService
+participant notificationService
+
+endUser -> postService : Add vote
+
+' To be made async in design
+postService -> endUser : Success
+postService -> notificationService: Create notification
+
+@enduml


### PR DESCRIPTION
### Add the following diagrams:

- Entity Relation Diagrams (ERD) for all the entities (posts, votes, options_groups, options & media)
- Sequence diagram for post creation
- Sequence diagram for post request
- Sequence diagram for add vote on an option 