### PR TITLE
Fix api routes

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { PromModule } from '@digikare/nestjs-prom';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -7,7 +7,10 @@ import { MediaModule } from './media/media.module';
 import { VotesModule } from './votes/votes.module';
 import { PostsModule } from './posts/posts.module';
 import configuration from './config/configuration';
+import {} from 'path-to-regexp';
 import config from './config/database';
+import * as swaggerUi from 'swagger-ui-express';
+import * as swaggerDocument from '../openAPI/post.openAPI.json';
 
 const evnVariable = process.env.NODE_ENV || 'development';
 @Module({
@@ -32,4 +35,12 @@ const evnVariable = process.env.NODE_ENV || 'development';
   controllers: [],
   providers: [],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  // Add swagger middleware to /api endpoint only
+  configure(consumer: MiddlewareConsumer) {
+    consumer
+      .apply(swaggerUi.serve, swaggerUi.setup(swaggerDocument))
+      .exclude('/api/(.[a-z0-9]*)')
+      .forRoutes('/');
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,12 +5,10 @@ import * as helmet from 'helmet';
 import * as rateLimit from 'express-rate-limit';
 import * as cookieParser from 'cookie-parser';
 import * as compression from 'compression';
-import * as swaggerUi from 'swagger-ui-express';
 import { AppModule } from './app.module';
 import { AllExceptionsFilterLogger } from './logging/http-exceptions-logger.filter';
 import { winstonLoggerOptions } from './logging/winston.options';
 import { LoggingInterceptor } from './logging/logging.interceptor';
-import * as swaggerDocument from '../openAPI/post.openAPI.json';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -42,15 +40,12 @@ async function bootstrap() {
   app.useGlobalInterceptors(new LoggingInterceptor(logger));
   app.useGlobalFilters(new AllExceptionsFilterLogger(logger));
 
-  app.use('/health', (req: any, res: any, next: any) => {
+  app.use('/health', (req: any, res: any) => {
     res.send({ status: true });
   });
 
-  app.use('/api', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
-
   const configService = app.get(ConfigService);
   const port = configService.get('port');
-
   await app.listen(port);
 }
 bootstrap();


### PR DESCRIPTION
 #### Due to error from merging #57, all endpoints are routing to openAPI specs. The following steps were done to tackle this issue
 
- Remove swaggerUI middleware from the main file
- bind swaggerUI middleware to /api and exlude all the other routes 
 
 