### PR TITLE
fix issue when routing to endpoints

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -40,7 +40,7 @@ export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
     consumer
       .apply(swaggerUi.serve, swaggerUi.setup(swaggerDocument))
-      .exclude('/api/(.[a-z0-9]*)')
+      .exclude('/api/(.[a-z0-9-/]*)')
       .forRoutes('/');
   }
 }


### PR DESCRIPTION
- There is an issue when reaching out for any endpoint at /api/post/NAME. it would response with openAPI definitions instead. 

- Accordingly, the regex which prevents all endpoints was updated. 