### PR TITLE
Add vote endpoint

### DIFF
--- a/examples/examples.http
+++ b/examples/examples.http
@@ -42,7 +42,7 @@ content-type: application/json
 
 ##################
 // POST /api/posts/:postid/groups
-POST http://localhost:3000/api/posts/94c4e1a3-19b1-4a19-bf39-0d0df81da29c/groups HTTP/1.1
+POST http://localhost:3000/api/posts/ba858c96-ddeb-4523-8f10-71030d88807f/groups HTTP/1.1
 content-type: application/json
 
 {   
@@ -60,7 +60,7 @@ content-type: application/json
 
 ###
 
-POST http://localhost:3000/api/posts/e67afb17-cea3-48ea-af71-87e80da0e478/groups HTTP/1.1
+POST http://localhost:3000/api/posts/ba858c96-ddeb-4523-8f10-71030d88807f/groups HTTP/1.1
 content-type: application/json
 
 {   
@@ -77,7 +77,7 @@ content-type: application/json
 
 ###
 
-POST http://localhost:3000/api/posts/e67afb17-cea3-48ea-af71-87e80da0e478/groups HTTP/1.1
+POST http://localhost:3000/api/posts/ba858c96-ddeb-4523-8f10-71030d88807f/groups HTTP/1.1
 content-type: application/json
 
 {   
@@ -117,3 +117,5 @@ content-type: application/json
 
 ##################
 // PUT /api/votes/:optionid
+
+PUT http://localhost:3000/api/votes/cbc38f0c-fa0e-41c4-9d1d-f0269fd96e3c HTTP/1.1

--- a/examples/examples.http
+++ b/examples/examples.http
@@ -101,7 +101,7 @@ content-type: application/json
 
 ##################
 // DELETE /api/posts/:postid
-DELETE http://localhost:3000/api/posts/647b5049-2c4a-4d3b-858b-23f5aade1b60 HTTP/1.1
+DELETE http://localhost:3000/api/posts/219e9e3d-f209-4f64-b816-6bba8e0d2e43 HTTP/1.1
 content-type: application/json
 
 
@@ -120,4 +120,4 @@ content-type: application/json
 ##################
 // PUT /api/votes/:optionid
 
-PUT http://localhost:3000/api/votes/8898c208-0be3-4e92-a83b-862a688ba8dc HTTP/1.1
+PUT http://localhost:3000/api/votes/a502658a-d92f-4759-a0fc-8fd79e656172 HTTP/1.1

--- a/examples/examples.http
+++ b/examples/examples.http
@@ -120,4 +120,4 @@ content-type: application/json
 ##################
 // PUT /api/votes/:optionid
 
-PUT http://localhost:3000/api/votes/cbc38f0c-fa0e-41c4-9d1d-f0269fd96e3c HTTP/1.1
+PUT http://localhost:3000/api/votes/8898c208-0be3-4e92-a83b-862a688ba8dc HTTP/1.1

--- a/src/posts/entities/option.entity.ts
+++ b/src/posts/entities/option.entity.ts
@@ -1,6 +1,7 @@
 import Model, { POSTS_SCHEMA } from '../../shared/entity.model';
-import { Column, Entity, ManyToOne } from 'typeorm';
+import { Column, Entity, ManyToOne, OneToMany } from 'typeorm';
 import { OptiosnGroup } from './optionsGroup.entity';
+import { Vote } from './vote.entity';
 
 @Entity({ name: 'options', schema: POSTS_SCHEMA })
 export class Option extends Model {
@@ -15,4 +16,7 @@ export class Option extends Model {
     onDelete: 'CASCADE',
   })
   optionsGroup: OptiosnGroup;
+
+  @OneToMany(() => Vote, (vote) => vote.option)
+  votes: Vote[];
 }

--- a/src/posts/entities/option.entity.ts
+++ b/src/posts/entities/option.entity.ts
@@ -1,7 +1,7 @@
 import Model, { POSTS_SCHEMA } from '../../shared/entity.model';
 import { Column, Entity, ManyToOne, OneToMany } from 'typeorm';
 import { OptiosnGroup } from './optionsGroup.entity';
-import { Vote } from './vote.entity';
+import { Vote } from '../../votes/entities/vote.entity';
 
 @Entity({ name: 'options', schema: POSTS_SCHEMA })
 export class Option extends Model {

--- a/src/posts/entities/vote.entity.ts
+++ b/src/posts/entities/vote.entity.ts
@@ -1,0 +1,9 @@
+import Model, { POSTS_SCHEMA } from '../../shared/entity.model';
+import { Entity, ManyToOne } from 'typeorm';
+import { Option } from './option.entity';
+
+@Entity({ name: 'vote', schema: POSTS_SCHEMA })
+export class Vote extends Model {
+  @ManyToOne(() => Option, (option) => option.votes)
+  option: Option;
+}

--- a/src/posts/posts.controller.spec.ts
+++ b/src/posts/posts.controller.spec.ts
@@ -1,6 +1,6 @@
 import { NotImplementedException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { PostIdParam } from 'src/shared/validations/postIdParam.validator';
+import { PostIdParam } from 'src/shared/validations/uuid.validator';
 import { OptionsGroupCreationDto } from './dto/optionGroupCreation.dto';
 import { PostsController } from './posts.controller';
 import { PostsService } from './posts.service';

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -10,7 +10,7 @@ import {
   Post,
   UseFilters,
 } from '@nestjs/common';
-import { PostIdParam } from '../shared/validations/postIdParam.validator';
+import { PostIdParam } from '../shared/validations/uuid.validator';
 import { OptionsGroupCreationDto } from './dto/optionGroupCreation.dto';
 import { OptionsGroups } from './interfaces/optionsGroup.interface';
 import { PostCreationDto } from './dto/postCreation.dto';

--- a/src/shared/migrations/1622098062239-Initial_migration.ts
+++ b/src/shared/migrations/1622098062239-Initial_migration.ts
@@ -17,6 +17,9 @@ export class InitialMigration1622098062239 implements MigrationInterface {
     await queryRunner.query(
       `CREATE TABLE IF NOT EXISTS "${POSTS_SCHEMA}"."options" ("id" SERIAL NOT NULL, "uuid" uuid NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "body" character varying NOT NULL, "vote_count" integer NOT NULL, "optionsGroupId" integer, CONSTRAINT "PK_b0ba798adfe36f8d5c9429759f2" PRIMARY KEY ("id"), CONSTRAINT "FK_cff2c5c22b420f553677f550126" FOREIGN KEY ("optionsGroupId") REFERENCES "${POSTS_SCHEMA}"."options_groups"("id") ON DELETE CASCADE ON UPDATE NO ACTION)`,
     );
+    await queryRunner.query(
+      `CREATE TABLE IF NOT EXISTS "${POSTS_SCHEMA}"."votes" ("id" SERIAL NOT NULL, "uuid" uuid NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "optionId" integer, CONSTRAINT "FK_26c647863c296d49e748b5ef98f" FOREIGN KEY ("optionId") REFERENCES "${POSTS_SCHEMA}"."options"("id") ON DELETE CASCADE ON UPDATE NO ACTION)`,
+    );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
@@ -26,5 +29,6 @@ export class InitialMigration1622098062239 implements MigrationInterface {
       `DROP TABLE IF EXISTS "${POSTS_SCHEMA}"."options_groups"`,
     );
     await queryRunner.query(`DROP TABLE IF EXISTS "${POSTS_SCHEMA}"."posts"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "${POSTS_SCHEMA}"."vote"`);
   }
 }

--- a/src/shared/validations/uuid.validator.ts
+++ b/src/shared/validations/uuid.validator.ts
@@ -4,3 +4,8 @@ export class PostIdParam {
   @IsUUID(4, { message: 'post id is not correct' })
   postid: string;
 }
+
+export class OptionIdParam {
+  @IsUUID(4, { message: 'option id is not correct' })
+  optionid: string;
+}

--- a/src/votes/entities/vote.entity.ts
+++ b/src/votes/entities/vote.entity.ts
@@ -4,6 +4,9 @@ import { Option } from '../../posts/entities/option.entity';
 
 @Entity({ name: 'votes', schema: POSTS_SCHEMA })
 export class Vote extends Model {
-  @ManyToOne(() => Option, (option) => option.votes)
+  @ManyToOne(() => Option, (option) => option.votes, {
+    cascade: true,
+    onDelete: 'CASCADE',
+  })
   option: Option;
 }

--- a/src/votes/entities/vote.entity.ts
+++ b/src/votes/entities/vote.entity.ts
@@ -2,7 +2,7 @@ import Model, { POSTS_SCHEMA } from '../../shared/entity.model';
 import { Entity, ManyToOne } from 'typeorm';
 import { Option } from '../../posts/entities/option.entity';
 
-@Entity({ name: 'vote', schema: POSTS_SCHEMA })
+@Entity({ name: 'votes', schema: POSTS_SCHEMA })
 export class Vote extends Model {
   @ManyToOne(() => Option, (option) => option.votes)
   option: Option;

--- a/src/votes/entities/vote.entity.ts
+++ b/src/votes/entities/vote.entity.ts
@@ -1,6 +1,6 @@
 import Model, { POSTS_SCHEMA } from '../../shared/entity.model';
 import { Entity, ManyToOne } from 'typeorm';
-import { Option } from './option.entity';
+import { Option } from '../../posts/entities/option.entity';
 
 @Entity({ name: 'vote', schema: POSTS_SCHEMA })
 export class Vote extends Model {

--- a/src/votes/entities/votes.repository.spec.ts
+++ b/src/votes/entities/votes.repository.spec.ts
@@ -1,0 +1,88 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { VoteRepository } from './votes.repository';
+
+const mockOption = {
+  vote_count: 0,
+  uuid: 'correct-uuid',
+};
+
+const mockVotes = [];
+
+jest.mock('typeorm', () => ({
+  EntityRepository: () => jest.fn(),
+  Repository: class Repository {},
+  Entity: () => jest.fn(),
+  BaseEntity: class Mock {},
+  BeforeInsert: () => jest.fn(),
+  BeforeUpdate: () => jest.fn(),
+  Column: () => jest.fn(),
+  CreateDateColumn: () => jest.fn(),
+  PrimaryGeneratedColumn: () => jest.fn(),
+  UpdateDateColumn: () => jest.fn(),
+  OneToMany: () => jest.fn(),
+  ManyToOne: () => jest.fn(),
+}));
+
+jest.mock('../../posts/entities/option.entity', () => ({
+  Option: class MockClass {
+    static findOneOrFail(search_options) {
+      const {
+        where: { uuid },
+      } = search_options;
+      if (uuid === mockOption.uuid)
+        return Promise.resolve({
+          ...mockOption,
+          optionsGroup: { options: [mockOption, mockOption] },
+          save: jest.fn(() => {
+            mockOption.vote_count++;
+          }),
+        });
+      else return Promise.reject({ name: 'EntityNotFound' });
+    }
+  },
+}));
+
+jest.mock('./vote.entity', () => ({
+  Vote: class MockClass {
+    save = jest.fn(() => {
+      mockVotes.push({ optionId: 'id' });
+    });
+  },
+}));
+
+describe('Votes Repository', () => {
+  let voteRepository: VoteRepository;
+  beforeEach(async () => {
+    const mockModule: TestingModule = await Test.createTestingModule({
+      providers: [VoteRepository],
+    }).compile();
+    voteRepository = mockModule.get<VoteRepository>(VoteRepository);
+  });
+  it('should be defined and have necessary methods', () => {
+    expect(voteRepository).toBeDefined();
+    expect(voteRepository).toHaveProperty('addVote');
+  });
+
+  describe('addVote method', () => {
+    it('should throw if post wasnt found', () => {
+      const response = voteRepository.addVote('nonexistent-uuid');
+      expect(response).rejects.toThrow(new NotFoundException());
+    });
+    it('should save a new record to votes', async () => {
+      const prevVotesRecords = mockVotes.length;
+      await voteRepository.addVote('correct-uuid');
+      expect(mockVotes.length).toBe(prevVotesRecords + 1);
+    });
+    it('should increment vote count by 1', async () => {
+      const prevVoteCount = mockOption.vote_count;
+      await voteRepository.addVote('correct-uuid');
+      expect(mockOption.vote_count).toBe(prevVoteCount + 1);
+    });
+    it('should respond with all option votes in the same group', async () => {
+      const response = await voteRepository.addVote('correct-uuid');
+      expect(response[0]).toHaveProperty('votes_count');
+      expect(response[0]).toHaveProperty('optionId');
+    });
+  });
+});

--- a/src/votes/entities/votes.repository.ts
+++ b/src/votes/entities/votes.repository.ts
@@ -5,7 +5,6 @@ import {
   InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common';
-import { OptiosnGroup } from 'src/posts/entities/optionsGroup.entity';
 
 @EntityRepository(Vote)
 export class VoteRepository extends Repository<Vote> {
@@ -17,11 +16,11 @@ export class VoteRepository extends Repository<Vote> {
       vote.option = option;
       await vote.save();
 
-      option.votes.push(vote);
       option.vote_count++;
       await option.save();
     } catch (error) {
-      if (error) throw new NotFoundException();
+      console.log(error);
+      if (error.name === 'EntityNotFound') throw new NotFoundException();
       else throw new InternalServerErrorException();
     }
   }

--- a/src/votes/entities/votes.repository.ts
+++ b/src/votes/entities/votes.repository.ts
@@ -1,16 +1,19 @@
-import { Option } from '../../posts/entities/option.entity';
 import { EntityRepository, Repository } from 'typeorm';
-import { Vote } from './vote.entity';
 import {
   InternalServerErrorException,
   NotFoundException,
 } from '@nestjs/common';
+import { Vote } from './vote.entity';
+import { Option } from '../../posts/entities/option.entity';
 
 @EntityRepository(Vote)
 export class VoteRepository extends Repository<Vote> {
   async addVote(optionId: string) {
     try {
-      const option = await Option.findOneOrFail({ where: { uuid: optionId } });
+      const option = await Option.findOneOrFail({
+        where: { uuid: optionId },
+        relations: ['optionsGroup', 'optionsGroup.options'],
+      });
 
       const vote = new Vote();
       vote.option = option;
@@ -18,8 +21,12 @@ export class VoteRepository extends Repository<Vote> {
 
       option.vote_count++;
       await option.save();
+
+      const response = option.optionsGroup.options.map((option) => {
+        return { votes_count: option.vote_count, optionId: option.uuid };
+      });
+      return response;
     } catch (error) {
-      console.log(error);
       if (error.name === 'EntityNotFound') throw new NotFoundException();
       else throw new InternalServerErrorException();
     }

--- a/src/votes/entities/votes.repository.ts
+++ b/src/votes/entities/votes.repository.ts
@@ -1,0 +1,28 @@
+import { Option } from '../../posts/entities/option.entity';
+import { EntityRepository, Repository } from 'typeorm';
+import { Vote } from './vote.entity';
+import {
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { OptiosnGroup } from 'src/posts/entities/optionsGroup.entity';
+
+@EntityRepository(Vote)
+export class VoteRepository extends Repository<Vote> {
+  async addVote(optionId: string) {
+    try {
+      const option = await Option.findOneOrFail({ where: { uuid: optionId } });
+
+      const vote = new Vote();
+      vote.option = option;
+      await vote.save();
+
+      option.votes.push(vote);
+      option.vote_count++;
+      await option.save();
+    } catch (error) {
+      if (error) throw new NotFoundException();
+      else throw new InternalServerErrorException();
+    }
+  }
+}

--- a/src/votes/interfaces/optionsVotes.interface.ts
+++ b/src/votes/interfaces/optionsVotes.interface.ts
@@ -1,0 +1,4 @@
+export interface OptionsVotes {
+  votes_count: number;
+  optionId: string;
+}

--- a/src/votes/votes.controller.spec.ts
+++ b/src/votes/votes.controller.spec.ts
@@ -3,13 +3,20 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { VotesController } from './votes.controller';
 import { VotesService } from './votes.service';
 
+const mockService = { addVote: jest.fn(() => Promise.resolve(['options'])) };
+
 describe('VotesController', () => {
   let controller: VotesController;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [VotesController],
-      providers: [{ provide: VotesService, useValue: { addVote: jest.fn() } }],
+      providers: [
+        {
+          provide: VotesService,
+          useValue: mockService,
+        },
+      ],
     }).compile();
 
     controller = module.get<VotesController>(VotesController);
@@ -19,9 +26,15 @@ describe('VotesController', () => {
     expect(controller).toBeDefined();
   });
 
-  // describe('addVote function', () => {
-  //   it('should throw not implemented', () => {
-  //     expect(controller.addVote).toThrowError(new NotImplementedException());
-  //   });
-  // });
+  describe('addVote', () => {
+    const params = { optionId: 'uuid' };
+    it('should call service function with optionId', async () => {
+      controller.addVote(params.optionId);
+      expect(mockService.addVote).toBeCalledWith(params.optionId);
+    });
+    it('should return whatever service method returns', () => {
+      const res = controller.addVote(params.optionId);
+      expect(res).resolves.toEqual(['options']);
+    });
+  });
 });

--- a/src/votes/votes.controller.spec.ts
+++ b/src/votes/votes.controller.spec.ts
@@ -1,4 +1,3 @@
-import { NotImplementedException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { VotesController } from './votes.controller';
 import { VotesService } from './votes.service';
@@ -27,13 +26,13 @@ describe('VotesController', () => {
   });
 
   describe('addVote', () => {
-    const params = { optionId: 'uuid' };
+    const params = { optionid: 'uuid' };
     it('should call service function with optionId', async () => {
-      controller.addVote(params.optionId);
-      expect(mockService.addVote).toBeCalledWith(params.optionId);
+      controller.addVote(params);
+      expect(mockService.addVote).toBeCalledWith(params.optionid);
     });
     it('should return whatever service method returns', () => {
-      const res = controller.addVote(params.optionId);
+      const res = controller.addVote(params);
       expect(res).resolves.toEqual(['options']);
     });
   });

--- a/src/votes/votes.controller.spec.ts
+++ b/src/votes/votes.controller.spec.ts
@@ -9,7 +9,7 @@ describe('VotesController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [VotesController],
-      providers: [VotesService],
+      providers: [{ provide: VotesService, useValue: { addVote: jest.fn() } }],
     }).compile();
 
     controller = module.get<VotesController>(VotesController);
@@ -19,9 +19,9 @@ describe('VotesController', () => {
     expect(controller).toBeDefined();
   });
 
-  describe('addVote function', () => {
-    it('should throw not implemented', () => {
-      expect(controller.addVote).toThrowError(new NotImplementedException());
-    });
-  });
+  // describe('addVote function', () => {
+  //   it('should throw not implemented', () => {
+  //     expect(controller.addVote).toThrowError(new NotImplementedException());
+  //   });
+  // });
 });

--- a/src/votes/votes.controller.ts
+++ b/src/votes/votes.controller.ts
@@ -1,12 +1,14 @@
 import { Controller, Param, Put } from '@nestjs/common';
+import { OptionIdParam } from '../shared/validations/uuid.validator';
 import { VotesService } from './votes.service';
+import { OptionsVotes } from './interfaces/optionsVotes.interface';
 
 @Controller('votes')
 export class VotesController {
   constructor(private votesService: VotesService) {}
 
   @Put('/:optionid')
-  addVote(@Param('optionid') optionId: string) {
-    return this.votesService.addVote(optionId);
+  addVote(@Param() params: OptionIdParam): Promise<OptionsVotes[]> {
+    return this.votesService.addVote(params.optionid);
   }
 }

--- a/src/votes/votes.controller.ts
+++ b/src/votes/votes.controller.ts
@@ -6,7 +6,7 @@ export class VotesController {
   constructor(private votesService: VotesService) {}
 
   @Put('/:optionid')
-  addVote(@Param() optionId: string) {
+  addVote(@Param('optionid') optionId: string) {
     return this.votesService.addVote(optionId);
   }
 }

--- a/src/votes/votes.controller.ts
+++ b/src/votes/votes.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, NotImplementedException, Put } from '@nestjs/common';
+import { Controller, Param, Put } from '@nestjs/common';
 import { VotesService } from './votes.service';
 
 @Controller('votes')
@@ -6,7 +6,7 @@ export class VotesController {
   constructor(private votesService: VotesService) {}
 
   @Put('/:optionid')
-  addVote() {
-    throw new NotImplementedException();
+  addVote(@Param() optionId: string) {
+    return this.votesService.addVote(optionId);
   }
 }

--- a/src/votes/votes.module.ts
+++ b/src/votes/votes.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { VoteRepository } from './entities/votes.repository';
 import { VotesController } from './votes.controller';
 import { VotesService } from './votes.service';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([VoteRepository])],
   controllers: [VotesController],
   providers: [VotesService],
 })

--- a/src/votes/votes.service.spec.ts
+++ b/src/votes/votes.service.spec.ts
@@ -6,7 +6,15 @@ describe('VotesService', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [VotesService],
+      providers: [
+        VotesService,
+        {
+          provide: VotesService,
+          useValue: {
+            addVote: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     service = module.get<VotesService>(VotesService);

--- a/src/votes/votes.service.spec.ts
+++ b/src/votes/votes.service.spec.ts
@@ -1,5 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { VoteRepository } from './entities/votes.repository';
 import { VotesService } from './votes.service';
+
+const mockRepository = {
+  addVote: jest.fn(() => Promise.resolve(['options'])),
+};
 
 describe('VotesService', () => {
   let service: VotesService;
@@ -9,10 +14,8 @@ describe('VotesService', () => {
       providers: [
         VotesService,
         {
-          provide: VotesService,
-          useValue: {
-            addVote: jest.fn(),
-          },
+          provide: VoteRepository,
+          useValue: mockRepository,
         },
       ],
     }).compile();
@@ -22,5 +25,17 @@ describe('VotesService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+    expect(service).toHaveProperty('addVote');
+  });
+
+  describe('addVote method', () => {
+    it('should call repository fn with optionId', () => {
+      service.addVote('uuid');
+      expect(mockRepository.addVote).toHaveBeenCalledWith('uuid');
+    });
+    it('should return what repository method returns', () => {
+      const res = service.addVote('uuid');
+      expect(res).resolves.toEqual(['options']);
+    });
   });
 });

--- a/src/votes/votes.service.ts
+++ b/src/votes/votes.service.ts
@@ -2,11 +2,12 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Vote } from './entities/vote.entity';
 import { VoteRepository } from './entities/votes.repository';
+import { OptionsVotes } from './interfaces/optionsVotes.interface';
 
 @Injectable()
 export class VotesService {
   constructor(@InjectRepository(Vote) private voteRepository: VoteRepository) {}
-  addVote(optionId: string) {
+  addVote(optionId: string): Promise<OptionsVotes[]> {
     return this.voteRepository.addVote(optionId);
   }
 }

--- a/src/votes/votes.service.ts
+++ b/src/votes/votes.service.ts
@@ -1,4 +1,12 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Vote } from './entities/vote.entity';
+import { VoteRepository } from './entities/votes.repository';
 
 @Injectable()
-export class VotesService {}
+export class VotesService {
+  constructor(@InjectRepository(Vote) private voteRepository: VoteRepository) {}
+  addVote(optionId: string) {
+    return this.voteRepository.addVote(optionId);
+  }
+}


### PR DESCRIPTION
Whats in this PR:
- Controller with tests.
- Service with tests.
- Repository with tests.
- New votes entity.
- Updated migrations to add votes table.

Finished upvoting logic: now an option can be upvoted through `PUT /votes/{optionid}` endpoint.
