### PR TITLE
Update with user table 

### DIFF
--- a/examples/examples.http
+++ b/examples/examples.http
@@ -1,7 +1,7 @@
-@postId = 473be085-aa74-4026-9ee7-e5e29bf13535
+@postId = 0eff1e27-3bd6-4154-a292-0efc36f0be71
 @groupId = 48cf88df-e3cf-4caa-aae5-cc1ade55bcb5
-@optionId = 3184c41b-4a30-48d9-b0d8-747039493001
-@userId = 1
+@optionId = bc211b18-9be0-4822-b274-36ea24b9eb84
+@userId = 3ad4e0f5-1787-46fa-851f-d7dddbfaf2c3
 
 // POST /api/posts
 //////////////////

--- a/examples/posts_quries.pgsql
+++ b/examples/posts_quries.pgsql
@@ -1,3 +1,5 @@
+SELECT * FROM pickify_posts.users;
+
 select * from pickify_posts.posts;
 
 SELECT * FROM pickify_posts.options_groups;

--- a/src/posts/entities/option.entity.ts
+++ b/src/posts/entities/option.entity.ts
@@ -1,5 +1,5 @@
 import Model, { POSTS_SCHEMA } from '../../shared/entity.model';
-import { Column, Entity, ManyToOne, OneToMany } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
 import { OptiosnGroup } from './optionsGroup.entity';
 import { Vote } from '../../votes/entities/vote.entity';
 
@@ -15,6 +15,7 @@ export class Option extends Model {
     cascade: true,
     onDelete: 'CASCADE',
   })
+  @JoinColumn({ name: 'options_group_id' })
   optionsGroup: OptiosnGroup;
 
   @OneToMany(() => Vote, (vote) => vote.option)

--- a/src/posts/entities/option.repository.ts
+++ b/src/posts/entities/option.repository.ts
@@ -32,10 +32,11 @@ export class OptionRepository extends Repository<Option> {
    * get option with relation to vote, grous & post
    */
 
-  public async findOptionById(optionId: string): Promise<Option> {
+  public async findDetailedOptionById(optionId: string): Promise<Option> {
     return await this.createQueryBuilder('options')
       .where('options.uuid = :optionId', { optionId })
       .leftJoinAndSelect('options.votes', 'vote')
+      .leftJoinAndSelect('vote.user', 'user')
       .leftJoinAndSelect('options.optionsGroup', 'optionsGroup')
       .leftJoinAndSelect('optionsGroup.options', 'option')
       .leftJoinAndSelect('optionsGroup.post', 'post')

--- a/src/posts/entities/optionsGroup.entity.ts
+++ b/src/posts/entities/optionsGroup.entity.ts
@@ -1,6 +1,6 @@
 // import { OneToMany } from 'typeorm';
 import Model, { POSTS_SCHEMA } from '../../shared/entity.model';
-import { Column, Entity, ManyToOne, OneToMany } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
 import { Option } from './option.entity';
 import { Post } from './post.entity';
 
@@ -18,5 +18,6 @@ export class OptiosnGroup extends Model {
     cascade: true,
     onDelete: 'CASCADE',
   })
+  @JoinColumn({ name: 'post_id' })
   post: Post;
 }

--- a/src/posts/entities/post.entity.ts
+++ b/src/posts/entities/post.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, OneToMany, ManyToOne } from 'typeorm';
+import { Entity, Column, OneToMany, JoinColumn, ManyToOne } from 'typeorm';
 
 import Model, { POSTS_SCHEMA } from '../../shared/entity.model';
 import { OptiosnGroup } from './optionsGroup.entity';
@@ -30,5 +30,6 @@ export class Post extends Model {
     cascade: true,
     onDelete: 'CASCADE',
   })
+  @JoinColumn({ name: 'user_id' })
   user: User;
 }

--- a/src/posts/entities/post.entity.ts
+++ b/src/posts/entities/post.entity.ts
@@ -1,7 +1,8 @@
-import { Entity, Column, OneToMany } from 'typeorm';
+import { Entity, Column, OneToMany, ManyToOne } from 'typeorm';
 
 import Model, { POSTS_SCHEMA } from '../../shared/entity.model';
 import { OptiosnGroup } from './optionsGroup.entity';
+import { User } from './user.entity';
 
 @Entity({ name: 'posts', schema: POSTS_SCHEMA })
 export class Post extends Model {
@@ -15,9 +16,6 @@ export class Post extends Model {
   is_hidden: boolean;
 
   @Column()
-  user_id: number;
-
-  @Column()
   ready: boolean;
 
   @Column()
@@ -26,4 +24,11 @@ export class Post extends Model {
   // one to many relation with options_group entity
   @OneToMany(() => OptiosnGroup, (group) => group.post)
   groups: OptiosnGroup[];
+
+  // many to one relation with user entity
+  @ManyToOne(() => User, (user) => user.posts, {
+    cascade: true,
+    onDelete: 'CASCADE',
+  })
+  user: User;
 }

--- a/src/posts/entities/post.repository.ts
+++ b/src/posts/entities/post.repository.ts
@@ -1,6 +1,7 @@
 import { EntityRepository, Repository } from 'typeorm';
 import { PostCreationDto } from '../dto/postCreation.dto';
 import { Post } from './post.entity';
+import { User } from './user.entity';
 
 @EntityRepository(Post)
 export class PostRepository extends Repository<Post> {
@@ -9,14 +10,14 @@ export class PostRepository extends Repository<Post> {
    */
   public async createPost(
     postCreationDto: PostCreationDto,
-    userId: number,
+    user: User,
   ): Promise<Post> {
     const { caption, type, is_hidden } = postCreationDto;
     const post = this.create();
     post.caption = caption;
     post.type = type;
     post.is_hidden = is_hidden;
-    post.user_id = userId;
+    post.user = user;
     post.created = false;
     post.ready = false;
     return await this.save(post);
@@ -30,6 +31,9 @@ export class PostRepository extends Repository<Post> {
         'post.is_hidden',
         'post.created_at',
         'post.type',
+        'user.uuid',
+        'user.name',
+        'user.profile_pic',
         'group.uuid',
         'group.name',
         'option.uuid',
@@ -39,6 +43,7 @@ export class PostRepository extends Repository<Post> {
       .where('post.created = :created', { created: true })
       .leftJoin('post.groups', 'group')
       .leftJoin('group.options', 'option')
+      .leftJoin('post.user', 'user')
       .getMany();
   }
   /**
@@ -63,6 +68,9 @@ export class PostRepository extends Repository<Post> {
         'post.is_hidden',
         'post.created_at',
         'post.type',
+        'user.uuid',
+        'user.name',
+        'user.profile_pic',
         'group.uuid',
         'group.name',
         'option.uuid',
@@ -71,17 +79,19 @@ export class PostRepository extends Repository<Post> {
       ])
       .leftJoin('post.groups', 'group')
       .leftJoin('group.options', 'option')
+      .leftJoin('post.user', 'user')
       .where('post.uuid = :uuid', { uuid: postid })
       .getOne();
 
     return post;
   }
 
-  public async getPostById(postId: string): Promise<Post> {
+  public async getPostWithUserById(postId: string): Promise<Post> {
     return await this.createQueryBuilder('post')
       .where('post.uuid = :postId', {
         postId,
       })
+      .leftJoinAndSelect('post.user', 'user')
       .getOne();
   }
 }

--- a/src/posts/entities/post.repository.ts
+++ b/src/posts/entities/post.repository.ts
@@ -86,7 +86,7 @@ export class PostRepository extends Repository<Post> {
     return post;
   }
 
-  public async getPostWithUserById(postId: string): Promise<Post> {
+  public async getPostById(postId: string): Promise<Post> {
     return await this.createQueryBuilder('post')
       .where('post.uuid = :postId', {
         postId,

--- a/src/posts/entities/user.entity.ts
+++ b/src/posts/entities/user.entity.ts
@@ -1,0 +1,21 @@
+import Model, { POSTS_SCHEMA } from '../../shared/entity.model';
+import { Column, Entity, OneToMany } from 'typeorm';
+import { Post } from './post.entity';
+import { Vote } from '../../votes/entities/vote.entity';
+
+@Entity({ name: 'users', schema: POSTS_SCHEMA })
+export class User extends Model {
+  @Column()
+  name: string;
+
+  @Column()
+  profile_pic: string;
+
+  // one to many relation with posts entity
+  @OneToMany(() => Post, (post) => post.user)
+  posts: Post[];
+
+  // one to many relation with votes entity
+  @OneToMany(() => Vote, (vote) => vote.user)
+  votes: Vote[];
+}

--- a/src/posts/entities/user.repository.ts
+++ b/src/posts/entities/user.repository.ts
@@ -1,0 +1,5 @@
+import { EntityRepository, Repository } from 'typeorm';
+import { User } from './user.entity';
+
+@EntityRepository(User)
+export class UserRepository extends Repository<User> {}

--- a/src/posts/interfaces/getPosts.interface.ts
+++ b/src/posts/interfaces/getPosts.interface.ts
@@ -4,7 +4,14 @@ export interface Post {
   is_hidden: boolean;
   created_at: Date;
   type: string;
+  user: User;
   options_groups: OptionsGroup;
+}
+
+export interface User {
+  id: string;
+  name: string;
+  profile_pic: string;
 }
 export interface OptionsGroup {
   groups: Group[];

--- a/src/posts/posts.controller.spec.ts
+++ b/src/posts/posts.controller.spec.ts
@@ -47,7 +47,7 @@ describe('PostsController', () => {
       expect(result).toEqual({ uuid: 'test id' });
 
       expect(service.createPost).toBeCalledTimes(1);
-      expect(service.createPost).toBeCalledWith(dto, +headers.Authorization);
+      expect(service.createPost).toBeCalledWith(dto, headers.Authorization);
     });
   });
 
@@ -89,7 +89,7 @@ describe('PostsController', () => {
       expect(service.createOptionGroup).toBeCalledWith(
         param.postid,
         dto,
-        +headers.Authorization,
+        headers.Authorization,
       );
       expect(data).toEqual('test creating groups');
     });
@@ -109,7 +109,7 @@ describe('PostsController', () => {
       expect(service.flagPost).toBeCalledWith(
         params.postid,
         dto.finished,
-        +headers.Authorization,
+        headers.Authorization,
       );
     });
   });
@@ -128,7 +128,7 @@ describe('PostsController', () => {
       await controller.deletePost(params, headers);
       expect(service.deletePost).toBeCalledWith(
         params.postid,
-        +headers.Authorization,
+        headers.Authorization,
       );
     });
   });

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -36,7 +36,7 @@ export class PostsController {
     @Headers() headers: { Authorization: string },
   ): Promise<PostCreationInterface> {
     const userId = headers.Authorization;
-    return this.postsService.createPost(postCreationDto, +userId);
+    return this.postsService.createPost(postCreationDto, userId);
   }
 
   @Get('/')
@@ -59,7 +59,7 @@ export class PostsController {
     const createdGroups = await this.postsService.createOptionGroup(
       params.postid,
       createGroupsDto,
-      +userId,
+      userId,
     );
     return createdGroups;
   }
@@ -75,7 +75,7 @@ export class PostsController {
     await this.postsService.flagPost(
       params.postid,
       flagPostDto.finished,
-      +userId,
+      userId,
     );
   }
 
@@ -86,6 +86,6 @@ export class PostsController {
     @Headers() headers: { Authorization: string },
   ) {
     const userId = headers.Authorization;
-    await this.postsService.deletePost(params.postid, +userId);
+    await this.postsService.deletePost(params.postid, userId);
   }
 }

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -5,6 +5,7 @@ import { PostsController } from './posts.controller';
 import { PostsService } from './posts.service';
 import { OptionRepository } from './entities/option.repository';
 import { OptionsGroupRepository } from './entities/optionsGroup.repository';
+import { UserRepository } from './entities/user.repository';
 
 @Module({
   imports: [
@@ -12,6 +13,7 @@ import { OptionsGroupRepository } from './entities/optionsGroup.repository';
       PostRepository,
       OptionsGroupRepository,
       OptionRepository,
+      UserRepository,
     ]),
   ],
   controllers: [PostsController],

--- a/src/posts/posts.service.spec.ts
+++ b/src/posts/posts.service.spec.ts
@@ -82,7 +82,7 @@ describe('PostsService', () => {
       };
 
       // mocks
-      postRepo.getPostWithUserById = jest.fn().mockResolvedValueOnce(foundPost);
+      postRepo.getPostById = jest.fn().mockResolvedValueOnce(foundPost);
       groupRepo.createGroup = jest
         .fn()
         .mockResolvedValue({ uuid: 'created-group-uuid' });
@@ -117,7 +117,7 @@ describe('PostsService', () => {
       };
 
       // mocks
-      postRepo.getPostWithUserById = jest.fn().mockResolvedValueOnce(undefined);
+      postRepo.getPostById = jest.fn().mockResolvedValueOnce(undefined);
       groupRepo.createGroup = jest
         .fn()
         .mockResolvedValue({ uuid: 'created-group-uuid' });
@@ -155,7 +155,7 @@ describe('PostsService', () => {
       };
 
       // mocks
-      postRepo.getPostWithUserById = jest.fn().mockResolvedValueOnce(foundPost);
+      postRepo.getPostById = jest.fn().mockResolvedValueOnce(foundPost);
       groupRepo.createGroup = jest
         .fn()
         .mockResolvedValue({ uuid: 'created-group-uuid' });
@@ -585,7 +585,7 @@ describe('PostsService', () => {
       const foundPost = { id: 1, user: { uuid: userId } };
 
       // mocks
-      postRepo.getPostWithUserById = jest.fn().mockResolvedValueOnce(foundPost);
+      postRepo.getPostById = jest.fn().mockResolvedValueOnce(foundPost);
 
       postRepo.flagPostCreation = jest.fn().mockResolvedValueOnce(undefined);
 
@@ -596,7 +596,7 @@ describe('PostsService', () => {
       expect(data).resolves.toBeUndefined();
     });
 
-    it('should have getPostWithUserById method that is called with post id', async () => {
+    it('should have getPostById method that is called with post id', async () => {
       // data
       const flag = true;
       const postid = 'test-post-uuid';
@@ -604,7 +604,7 @@ describe('PostsService', () => {
       const foundPost = { id: 1, user: { uuid: userId } };
 
       // mocks
-      postRepo.getPostWithUserById = jest.fn().mockResolvedValueOnce(foundPost);
+      postRepo.getPostById = jest.fn().mockResolvedValueOnce(foundPost);
 
       postRepo.flagPostCreation = jest.fn().mockResolvedValueOnce(undefined);
 
@@ -612,7 +612,7 @@ describe('PostsService', () => {
       await service.flagPost(postid, flag, userId);
 
       // assertions
-      expect(postRepo.getPostWithUserById).toBeCalledWith(postid);
+      expect(postRepo.getPostById).toBeCalledWith(postid);
     });
 
     it('should throw error if post is not found', () => {
@@ -622,7 +622,7 @@ describe('PostsService', () => {
       const userId = '3';
 
       // mocks
-      postRepo.getPostWithUserById = jest.fn().mockResolvedValueOnce(undefined);
+      postRepo.getPostById = jest.fn().mockResolvedValueOnce(undefined);
 
       postRepo.flagPostCreation = jest.fn().mockResolvedValueOnce(undefined);
 
@@ -643,7 +643,7 @@ describe('PostsService', () => {
       const foundPost = { id: 1, user: { uuid: 'user-dont-own-post' } };
 
       // mocks
-      postRepo.getPostWithUserById = jest.fn().mockResolvedValueOnce(foundPost);
+      postRepo.getPostById = jest.fn().mockResolvedValueOnce(foundPost);
 
       postRepo.flagPostCreation = jest.fn().mockResolvedValueOnce(undefined);
 
@@ -664,7 +664,7 @@ describe('PostsService', () => {
       const foundPost = { id: 1, user: { uuid: userId } };
 
       // mocks
-      postRepo.getPostWithUserById = jest.fn().mockResolvedValueOnce(foundPost);
+      postRepo.getPostById = jest.fn().mockResolvedValueOnce(foundPost);
 
       postRepo.flagPostCreation = jest.fn().mockResolvedValueOnce(undefined);
 
@@ -683,7 +683,7 @@ describe('PostsService', () => {
       const foundPost = { id: 1, user: { uuid: userId } };
 
       //mocks
-      postRepo.getPostWithUserById = jest.fn().mockResolvedValueOnce(foundPost);
+      postRepo.getPostById = jest.fn().mockResolvedValueOnce(foundPost);
       postRepo.remove = jest.fn().mockResolvedValueOnce(undefined);
 
       // action
@@ -693,21 +693,21 @@ describe('PostsService', () => {
       expect(res).resolves.toBeUndefined();
     });
 
-    it('should have getPostWithUserById method that is called with post id', async () => {
+    it('should have getPostById method that is called with post id', async () => {
       // data
       const userId = 'test-user-id';
       const postId = 'test-post-id';
       const foundPost = { id: 1, user: { uuid: userId } };
 
       //mocks
-      postRepo.getPostWithUserById = jest.fn().mockResolvedValueOnce(foundPost);
+      postRepo.getPostById = jest.fn().mockResolvedValueOnce(foundPost);
       postRepo.remove = jest.fn().mockResolvedValueOnce(undefined);
 
       // action
       await service.deletePost(postId, userId);
 
       // assertions
-      expect(postRepo.getPostWithUserById).toBeCalledWith(postId);
+      expect(postRepo.getPostById).toBeCalledWith(postId);
     });
 
     it('should throw error if post is not found', () => {
@@ -716,7 +716,7 @@ describe('PostsService', () => {
       const postId = 'test-post-uuid';
 
       //mocks
-      postRepo.getPostWithUserById = jest.fn().mockResolvedValueOnce(undefined);
+      postRepo.getPostById = jest.fn().mockResolvedValueOnce(undefined);
       postRepo.remove = jest.fn().mockResolvedValueOnce(undefined);
 
       // action
@@ -735,7 +735,7 @@ describe('PostsService', () => {
       const foundPost = { id: 1, user: { uuid: 'user-dont-own-post' } };
 
       //mocks
-      postRepo.getPostWithUserById = jest.fn().mockResolvedValueOnce(foundPost);
+      postRepo.getPostById = jest.fn().mockResolvedValueOnce(foundPost);
       postRepo.remove = jest.fn().mockResolvedValueOnce(undefined);
 
       // action
@@ -754,7 +754,7 @@ describe('PostsService', () => {
       const foundPost = { id: 1, user: { uuid: userId } };
 
       //mocks
-      postRepo.getPostWithUserById = jest.fn().mockResolvedValueOnce(foundPost);
+      postRepo.getPostById = jest.fn().mockResolvedValueOnce(foundPost);
       postRepo.remove = jest.fn().mockResolvedValueOnce(undefined);
 
       // action

--- a/src/posts/posts.service.spec.ts
+++ b/src/posts/posts.service.spec.ts
@@ -11,12 +11,14 @@ import {
   NotFoundException,
   UnauthorizedException,
 } from '@nestjs/common';
+import { UserRepository } from './entities/user.repository';
 
 describe('PostsService', () => {
   let service: PostsService;
   let optionRepo: OptionRepository;
   let groupRepo: OptionsGroupRepository;
   let postRepo: PostRepository;
+  let userRepo: UserRepository;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -25,6 +27,7 @@ describe('PostsService', () => {
         OptionsGroupRepository,
         OptionRepository,
         PostRepository,
+        UserRepository,
       ],
     }).compile();
 
@@ -32,6 +35,7 @@ describe('PostsService', () => {
     optionRepo = module.get<OptionRepository>(OptionRepository);
     groupRepo = module.get<OptionsGroupRepository>(OptionsGroupRepository);
     postRepo = module.get<PostRepository>(PostRepository);
+    userRepo = module.get<UserRepository>(UserRepository);
   });
 
   it('should be defined & have the necessary methods', () => {
@@ -48,8 +52,8 @@ describe('PostsService', () => {
     it('should return the ids of the created groups & options', async () => {
       // data
       const postId = 'test post id';
-      const userId = 3;
-      const foundPost = { id: 1, user_id: userId };
+      const userId = 'test-user-uuid';
+      const foundPost = { id: 1, user: { uuid: userId } };
       const dto: OptionsGroupCreationDto = {
         groups: [
           {
@@ -78,7 +82,7 @@ describe('PostsService', () => {
       };
 
       // mocks
-      postRepo.getPostById = jest.fn().mockResolvedValueOnce(foundPost);
+      postRepo.getPostWithUserById = jest.fn().mockResolvedValueOnce(foundPost);
       groupRepo.createGroup = jest
         .fn()
         .mockResolvedValue({ uuid: 'created-group-uuid' });
@@ -99,7 +103,7 @@ describe('PostsService', () => {
     it('should throw error if post not found', async () => {
       // data
       const postId = 'test post id';
-      const userId = 3;
+      const userId = '3';
       const dto: OptionsGroupCreationDto = {
         groups: [
           {
@@ -113,7 +117,7 @@ describe('PostsService', () => {
       };
 
       // mocks
-      postRepo.getPostById = jest.fn().mockResolvedValueOnce(undefined);
+      postRepo.getPostWithUserById = jest.fn().mockResolvedValueOnce(undefined);
       groupRepo.createGroup = jest
         .fn()
         .mockResolvedValue({ uuid: 'created-group-uuid' });
@@ -136,8 +140,8 @@ describe('PostsService', () => {
     it('should throw error if user is not post owner', async () => {
       // data
       const postId = 'test post id';
-      const userId = 3;
-      const foundPost = { id: 1, user_id: 2 };
+      const userId = 'user-owns-post';
+      const foundPost = { id: 1, user: { uuid: 'user-dont-own-post' } };
       const dto: OptionsGroupCreationDto = {
         groups: [
           {
@@ -151,7 +155,7 @@ describe('PostsService', () => {
       };
 
       // mocks
-      postRepo.getPostById = jest.fn().mockResolvedValueOnce(foundPost);
+      postRepo.getPostWithUserById = jest.fn().mockResolvedValueOnce(foundPost);
       groupRepo.createGroup = jest
         .fn()
         .mockResolvedValue({ uuid: 'created-group-uuid' });
@@ -180,18 +184,56 @@ describe('PostsService', () => {
         caption: 'test caption',
         is_hidden: false,
       };
-      const userId = 2;
+      const userId = 'test-user-uuid';
+
+      const user = {
+        uuid: 'test-user-uuid',
+        name: 'test-name',
+        profile_pic: 'test-picture-url',
+      };
 
       // mocks
       postRepo.createPost = jest
         .fn()
         .mockResolvedValueOnce({ uuid: 'created-post-uuid' });
 
+      userRepo.findOne = jest.fn().mockResolvedValue(user);
+
       // action
       const data = service.createPost(dto, userId);
 
       // assertions
       expect(data).resolves.toEqual({ id: 'created-post-uuid' });
+    });
+
+    it('should call userRepo.findOne with the appropriate parameters', async () => {
+      // data
+      const dto: PostCreationDto = {
+        type: 'text_poll',
+        caption: 'test caption',
+        is_hidden: false,
+      };
+      const userId = 'test-user-uuid';
+
+      const user = {
+        uuid: 'test-user-uuid',
+        name: 'test-name',
+        profile_pic: 'test-picture-url',
+      };
+
+      // mocks
+      postRepo.createPost = jest
+        .fn()
+        .mockResolvedValueOnce({ uuid: 'created-post-uuid' });
+
+      userRepo.findOne = jest.fn().mockResolvedValue(user);
+
+      // action
+      await service.createPost(dto, userId);
+
+      // assertions
+      expect(userRepo.findOne).toBeCalledWith({ where: { uuid: userId } });
+      expect(userRepo.findOne).toBeCalledTimes(1);
     });
 
     it('should call postRepo.createPost with the appropriate parameters', async () => {
@@ -201,18 +243,26 @@ describe('PostsService', () => {
         caption: 'test caption',
         is_hidden: false,
       };
-      const userId = 2;
+      const userId = 'test-user-uuid';
+
+      const user = {
+        uuid: 'test-user-uuid',
+        name: 'test-name',
+        profile_pic: 'test-picture-url',
+      };
 
       // mocks
       postRepo.createPost = jest
         .fn()
         .mockResolvedValueOnce({ uuid: 'created-post-uuid' });
 
+      userRepo.findOne = jest.fn().mockResolvedValue(user);
+
       // action
       await service.createPost(dto, userId);
 
       // assertions
-      expect(postRepo.createPost).toBeCalledWith(dto, userId);
+      expect(postRepo.createPost).toBeCalledWith(dto, user);
       expect(postRepo.createPost).toBeCalledTimes(1);
     });
   });
@@ -226,6 +276,11 @@ describe('PostsService', () => {
         is_hidden: false,
         created_at: 'test-creation-time',
         type: 'text poll',
+        user: {
+          uuid: 'test-user-uuid',
+          name: 'test',
+          profile_pic: 'test-url',
+        },
         groups: [
           {
             uuid: 'test-group-uuid',
@@ -266,6 +321,11 @@ describe('PostsService', () => {
         is_hidden: postInDB.is_hidden,
         created_at: postInDB.created_at,
         type: postInDB.type,
+        user: {
+          id: postInDB.user.uuid,
+          name: postInDB.user.name,
+          profile_pic: postInDB.user.profile_pic,
+        },
         options_groups: {
           groups: [
             {
@@ -306,6 +366,11 @@ describe('PostsService', () => {
         is_hidden: false,
         created_at: 'test-creation-time',
         type: 'text poll',
+        user: {
+          uuid: 'test-user-uuid',
+          name: 'test',
+          profile_pic: 'test-url',
+        },
         groups: [
           {
             uuid: 'test-group-uuid',
@@ -347,6 +412,11 @@ describe('PostsService', () => {
         is_hidden: postInDB.is_hidden,
         created_at: postInDB.created_at,
         type: postInDB.type,
+        user: {
+          id: postInDB.user.uuid,
+          name: postInDB.user.name,
+          profile_pic: postInDB.user.profile_pic,
+        },
         options_groups: {
           groups: [
             {
@@ -391,6 +461,11 @@ describe('PostsService', () => {
         is_hidden: false,
         created_at: 'test-creation-time',
         type: 'text poll',
+        user: {
+          uuid: 'test-user-uuid',
+          name: 'test',
+          profile_pic: 'test-url',
+        },
         groups: [
           {
             uuid: 'test-group-uuid',
@@ -411,6 +486,11 @@ describe('PostsService', () => {
         is_hidden: postInDB.is_hidden,
         created_at: postInDB.created_at,
         type: postInDB.type,
+        user: {
+          id: postInDB.user.uuid,
+          name: postInDB.user.name,
+          profile_pic: postInDB.user.profile_pic,
+        },
         options_groups: {
           groups: [
             {
@@ -501,11 +581,11 @@ describe('PostsService', () => {
       // data
       const flag = true;
       const postid = 'test-post-uuid';
-      const userId = 3;
-      const foundPost = { id: 1, user_id: userId };
+      const userId = 'test-user-uuid';
+      const foundPost = { id: 1, user: { uuid: userId } };
 
       // mocks
-      postRepo.getPostById = jest.fn().mockResolvedValueOnce(foundPost);
+      postRepo.getPostWithUserById = jest.fn().mockResolvedValueOnce(foundPost);
 
       postRepo.flagPostCreation = jest.fn().mockResolvedValueOnce(undefined);
 
@@ -516,15 +596,15 @@ describe('PostsService', () => {
       expect(data).resolves.toBeUndefined();
     });
 
-    it('should have getPostById method that is called with post id', async () => {
+    it('should have getPostWithUserById method that is called with post id', async () => {
       // data
       const flag = true;
       const postid = 'test-post-uuid';
-      const userId = 3;
-      const foundPost = { id: 1, user_id: userId };
+      const userId = 'test-user-uuid';
+      const foundPost = { id: 1, user: { uuid: userId } };
 
       // mocks
-      postRepo.getPostById = jest.fn().mockResolvedValueOnce(foundPost);
+      postRepo.getPostWithUserById = jest.fn().mockResolvedValueOnce(foundPost);
 
       postRepo.flagPostCreation = jest.fn().mockResolvedValueOnce(undefined);
 
@@ -532,17 +612,17 @@ describe('PostsService', () => {
       await service.flagPost(postid, flag, userId);
 
       // assertions
-      expect(postRepo.getPostById).toBeCalledWith(postid);
+      expect(postRepo.getPostWithUserById).toBeCalledWith(postid);
     });
 
     it('should throw error if post is not found', () => {
       // data
       const flag = true;
       const postid = 'test-post-uuid';
-      const userId = 3;
+      const userId = '3';
 
       // mocks
-      postRepo.getPostById = jest.fn().mockResolvedValueOnce(undefined);
+      postRepo.getPostWithUserById = jest.fn().mockResolvedValueOnce(undefined);
 
       postRepo.flagPostCreation = jest.fn().mockResolvedValueOnce(undefined);
 
@@ -559,11 +639,11 @@ describe('PostsService', () => {
       // data
       const flag = true;
       const postid = 'test-post-uuid';
-      const userId = 3;
-      const foundPost = { id: 1, user_id: 2 };
+      const userId = 'user-owns-post';
+      const foundPost = { id: 1, user: { uuid: 'user-dont-own-post' } };
 
       // mocks
-      postRepo.getPostById = jest.fn().mockResolvedValueOnce(foundPost);
+      postRepo.getPostWithUserById = jest.fn().mockResolvedValueOnce(foundPost);
 
       postRepo.flagPostCreation = jest.fn().mockResolvedValueOnce(undefined);
 
@@ -580,11 +660,11 @@ describe('PostsService', () => {
       // data
       const flag = true;
       const postid = 'test-post-uuid';
-      const userId = 3;
-      const foundPost = { id: 1, user_id: userId };
+      const userId = 'test-user-uuid';
+      const foundPost = { id: 1, user: { uuid: userId } };
 
       // mocks
-      postRepo.getPostById = jest.fn().mockResolvedValueOnce(foundPost);
+      postRepo.getPostWithUserById = jest.fn().mockResolvedValueOnce(foundPost);
 
       postRepo.flagPostCreation = jest.fn().mockResolvedValueOnce(undefined);
 
@@ -598,13 +678,12 @@ describe('PostsService', () => {
   describe('deletePost', () => {
     it('should return undefined', () => {
       // data
-      const userId = 2;
+      const userId = 'test-user-id';
       const postId = 'test-post-id';
+      const foundPost = { id: 1, user: { uuid: userId } };
 
       //mocks
-      postRepo.getPostById = jest
-        .fn()
-        .mockResolvedValueOnce({ id: 1, user_id: userId });
+      postRepo.getPostWithUserById = jest.fn().mockResolvedValueOnce(foundPost);
       postRepo.remove = jest.fn().mockResolvedValueOnce(undefined);
 
       // action
@@ -614,31 +693,30 @@ describe('PostsService', () => {
       expect(res).resolves.toBeUndefined();
     });
 
-    it('should have getPostById method that is called with post id', async () => {
+    it('should have getPostWithUserById method that is called with post id', async () => {
       // data
-      const userId = 2;
+      const userId = 'test-user-id';
       const postId = 'test-post-id';
+      const foundPost = { id: 1, user: { uuid: userId } };
 
       //mocks
-      postRepo.getPostById = jest
-        .fn()
-        .mockResolvedValueOnce({ id: 1, user_id: userId });
+      postRepo.getPostWithUserById = jest.fn().mockResolvedValueOnce(foundPost);
       postRepo.remove = jest.fn().mockResolvedValueOnce(undefined);
 
       // action
       await service.deletePost(postId, userId);
 
       // assertions
-      expect(postRepo.getPostById).toBeCalledWith(postId);
+      expect(postRepo.getPostWithUserById).toBeCalledWith(postId);
     });
 
     it('should throw error if post is not found', () => {
       // data
-      const userId = 2;
+      const userId = '2';
       const postId = 'test-post-uuid';
 
       //mocks
-      postRepo.getPostById = jest.fn().mockResolvedValueOnce(undefined);
+      postRepo.getPostWithUserById = jest.fn().mockResolvedValueOnce(undefined);
       postRepo.remove = jest.fn().mockResolvedValueOnce(undefined);
 
       // action
@@ -652,13 +730,12 @@ describe('PostsService', () => {
 
     it('should throw error if user is not owner of post', () => {
       // data
-      const userId = 2;
+      const userId = 'user-owns-post';
       const postId = 'test-post-uuid';
+      const foundPost = { id: 1, user: { uuid: 'user-dont-own-post' } };
 
       //mocks
-      postRepo.getPostById = jest
-        .fn()
-        .mockResolvedValueOnce({ uuid: 'test-uuid', user_id: 1 });
+      postRepo.getPostWithUserById = jest.fn().mockResolvedValueOnce(foundPost);
       postRepo.remove = jest.fn().mockResolvedValueOnce(undefined);
 
       // action
@@ -672,12 +749,12 @@ describe('PostsService', () => {
 
     it('should call postRepository.remove with the found post', async () => {
       // data
-      const userId = 2;
+      const userId = 'test-user-uuid';
       const postId = 'test-post-uuid';
-      const foundPost = { uuid: 'test-uuid', user_id: userId };
+      const foundPost = { id: 1, user: { uuid: userId } };
 
       //mocks
-      postRepo.getPostById = jest.fn().mockResolvedValueOnce(foundPost);
+      postRepo.getPostWithUserById = jest.fn().mockResolvedValueOnce(foundPost);
       postRepo.remove = jest.fn().mockResolvedValueOnce(undefined);
 
       // action

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -67,7 +67,7 @@ export class PostsService {
 
   async flagPost(postId: string, flag: boolean, userId: string): Promise<void> {
     // get post
-    const post = await this.postRepository.getPostWithUserById(postId);
+    const post = await this.postRepository.getPostById(postId);
 
     // check whether post is found
     if (!post) {
@@ -84,7 +84,7 @@ export class PostsService {
 
   async deletePost(postid: string, userId: string): Promise<void> {
     // get post
-    const post = await this.postRepository.getPostWithUserById(postid);
+    const post = await this.postRepository.getPostById(postid);
 
     // check whether post is found
     if (!post) {
@@ -107,7 +107,7 @@ export class PostsService {
     const response: OptionsGroups = { groups: [] };
 
     // get post
-    const post = await this.postRepository.getPostWithUserById(postid);
+    const post = await this.postRepository.getPostById(postid);
 
     // check whether post found
     if (!post) {

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -20,6 +20,7 @@ import {
 } from '@nestjs/common';
 import { isUserAuthorized } from '../shared/authorization/userAuthorization';
 import { LockedException } from '../shared/exceptions/locked.exception';
+import { UserRepository } from './entities/user.repository';
 
 @Injectable()
 export class PostsService {
@@ -27,6 +28,7 @@ export class PostsService {
     private postRepository: PostRepository,
     private optionRepository: OptionRepository,
     private groupRepository: OptionsGroupRepository,
+    private userRepository: UserRepository,
   ) {}
 
   private modifyGroupsData(currGroups: OptionGroupEntity[]): Group[] {
@@ -50,18 +52,22 @@ export class PostsService {
 
   async createPost(
     postCreationDto: PostCreationDto,
-    userId: number,
+    userId: string,
   ): Promise<PostCreationInterface> {
+    // get user to add post to it
+    const user = await this.userRepository.findOne({ where: { uuid: userId } });
+
+    // create the post
     const createdPost = await this.postRepository.createPost(
       postCreationDto,
-      userId,
+      user,
     );
     return { id: createdPost.uuid };
   }
 
-  async flagPost(postId: string, flag: boolean, userId: number): Promise<void> {
+  async flagPost(postId: string, flag: boolean, userId: string): Promise<void> {
     // get post
-    const post = await this.postRepository.getPostById(postId);
+    const post = await this.postRepository.getPostWithUserById(postId);
 
     // check whether post is found
     if (!post) {
@@ -76,9 +82,9 @@ export class PostsService {
     await this.postRepository.flagPostCreation(flag, post);
   }
 
-  async deletePost(postid: string, userId: number): Promise<void> {
+  async deletePost(postid: string, userId: string): Promise<void> {
     // get post
-    const post = await this.postRepository.getPostById(postid);
+    const post = await this.postRepository.getPostWithUserById(postid);
 
     // check whether post is found
     if (!post) {
@@ -96,12 +102,12 @@ export class PostsService {
   async createOptionGroup(
     postid: string,
     groupsCreationDto: OptionsGroupCreationDto,
-    userId: number,
+    userId: string,
   ): Promise<OptionsGroups> {
     const response: OptionsGroups = { groups: [] };
 
     // get post
-    const post = await this.postRepository.getPostById(postid);
+    const post = await this.postRepository.getPostWithUserById(postid);
 
     // check whether post found
     if (!post) {
@@ -133,6 +139,7 @@ export class PostsService {
 
     return response;
   }
+
   async getAllPosts(): Promise<Posts> {
     // get all posts from DB
     const currentPosts = await this.postRepository.getAllPosts();
@@ -145,6 +152,11 @@ export class PostsService {
         const groups: Group[] = this.modifyGroupsData(post.groups);
         return {
           id: post.uuid,
+          user: {
+            id: post.user.uuid,
+            name: post.user.name,
+            profile_pic: post.user.profile_pic,
+          },
           caption: post.caption,
           is_hidden: post.is_hidden,
           created_at: post.created_at,
@@ -154,6 +166,7 @@ export class PostsService {
       }),
     };
   }
+
   async getSinglePost(postId: string): Promise<Post> {
     const post = await this.postRepository.getDetailedPostById(postId);
 
@@ -166,18 +179,21 @@ export class PostsService {
         `Post with id: ${postId} still under creation...`,
       );
     }
-    const postUuid = post.uuid;
-    delete post['uuid'];
-    delete post['created'];
+
     //calling function to modify groups data
     const groups: Group[] = this.modifyGroupsData(post.groups);
 
-    //deleting old groups
-    delete post['groups'];
-
     return {
-      id: postUuid,
-      ...(post as any),
+      id: post.uuid,
+      user: {
+        id: post.user.uuid,
+        name: post.user.name,
+        profile_pic: post.user.profile_pic,
+      },
+      caption: post.caption,
+      is_hidden: post.is_hidden,
+      created_at: post.created_at,
+      type: post.type,
       options_groups: { groups: groups },
     };
   }

--- a/src/shared/authorization/userAuthorization.ts
+++ b/src/shared/authorization/userAuthorization.ts
@@ -2,9 +2,9 @@ import { ObjectLiteral } from '../interfaces/objectLiteral';
 
 export function isUserAuthorized<T extends ObjectLiteral>(
   entity: T,
-  userId: number,
+  userId: string,
 ): boolean {
-  if (entity.user_id !== userId) {
+  if (entity.user.uuid !== userId) {
     return false;
   }
   return true;

--- a/src/shared/middlewares/extendHeaders.middleware.ts
+++ b/src/shared/middlewares/extendHeaders.middleware.ts
@@ -15,8 +15,8 @@ export class ExtendHeadersMiddleware implements NestMiddleware {
       throw new UnauthorizedException('No user id');
     }
     const userId = req.headers.authorization.split(' ')[1];
-    // check if authorization is sent on form 'Bearer X' where X is number
-    if (req.headers.authorization.startsWith('Bearer ') && +userId) {
+    // check if authorization is sent on form 'Bearer X'
+    if (req.headers.authorization.startsWith('Bearer ')) {
       req.headers = {
         ...req.headers,
         Authorization: userId,

--- a/src/shared/migrations/1624449896646-add-user-entity-with-relations.ts
+++ b/src/shared/migrations/1624449896646-add-user-entity-with-relations.ts
@@ -10,10 +10,10 @@ export class addUserEntityWithRelations1624449896646
       `ALTER TABLE "${POSTS_SCHEMA}"."votes" DROP CONSTRAINT "FK_26c647863c296d49e748b5ef98f"`,
     );
     await queryRunner.query(
-      `ALTER TABLE "${POSTS_SCHEMA}"."votes" RENAME COLUMN "user_id" TO "userId"`,
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" DROP COLUMN "user_id"`,
     );
     await queryRunner.query(
-      `ALTER TABLE "${POSTS_SCHEMA}"."posts" RENAME COLUMN "user_id" TO "userId"`,
+      `ALTER TABLE "${POSTS_SCHEMA}"."posts" DROP COLUMN "user_id"`,
     );
     await queryRunner.query(
       `CREATE TABLE "${POSTS_SCHEMA}"."users" ("id" SERIAL NOT NULL, "uuid" uuid NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "name" character varying NOT NULL, "profile_pic" character varying NOT NULL, CONSTRAINT "PK_ddc86645bd3912d2b9a425880cd" PRIMARY KEY ("id"))`,
@@ -21,14 +21,17 @@ export class addUserEntityWithRelations1624449896646
     await queryRunner.query(
       `COMMENT ON COLUMN "${POSTS_SCHEMA}"."votes"."id" IS NULL`,
     );
+
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" ADD COLUMN "userId" integer NULL`,
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."posts" ADD COLUMN "userId" integer NULL`,
+    );
+
     await queryRunner.query(
       `ALTER TABLE "${POSTS_SCHEMA}"."votes" ADD CONSTRAINT "PK_7b73af10b8f22d092b684aa3ef4" PRIMARY KEY ("id")`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "${POSTS_SCHEMA}"."posts" ALTER COLUMN "userId" DROP NOT NULL`,
-    );
-    await queryRunner.query(
-      `COMMENT ON COLUMN "${POSTS_SCHEMA}"."posts"."userId" IS NULL`,
     );
     await queryRunner.query(
       `ALTER TABLE "${POSTS_SCHEMA}"."votes" ADD CONSTRAINT "FK_3d4dc54f63e51860aecb575413d" FOREIGN KEY ("optionId") REFERENCES "${POSTS_SCHEMA}"."options"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
@@ -51,12 +54,15 @@ export class addUserEntityWithRelations1624449896646
     await queryRunner.query(
       `ALTER TABLE "${POSTS_SCHEMA}"."votes" DROP CONSTRAINT "FK_3d4dc54f63e51860aecb575413d"`,
     );
+
     await queryRunner.query(
-      `COMMENT ON COLUMN "${POSTS_SCHEMA}"."posts"."userId" IS NULL`,
+      `ALTER TABLE "${POSTS_SCHEMA}"."posts" ADD COLUMN "user_id" integer NOT NULL`,
     );
+
     await queryRunner.query(
-      `ALTER TABLE "${POSTS_SCHEMA}"."posts" ALTER COLUMN "userId" SET NOT NULL`,
+      `ALTER TABLE "${POSTS_SCHEMA}"."vots" ADD COLUMN "user_id" integer NOT NULL`,
     );
+
     await queryRunner.query(
       `ALTER TABLE "${POSTS_SCHEMA}"."votes" DROP CONSTRAINT "PK_7b73af10b8f22d092b684aa3ef4"`,
     );
@@ -64,12 +70,7 @@ export class addUserEntityWithRelations1624449896646
       `COMMENT ON COLUMN "${POSTS_SCHEMA}"."votes"."id" IS NULL`,
     );
     await queryRunner.query(`DROP TABLE "${POSTS_SCHEMA}"."users"`);
-    await queryRunner.query(
-      `ALTER TABLE "${POSTS_SCHEMA}"."posts" RENAME COLUMN "userId" TO "user_id"`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "${POSTS_SCHEMA}"."votes" RENAME COLUMN "userId" TO "user_id"`,
-    );
+
     await queryRunner.query(
       `ALTER TABLE "${POSTS_SCHEMA}"."votes" ADD CONSTRAINT "FK_26c647863c296d49e748b5ef98f" FOREIGN KEY ("optionId") REFERENCES "pickify_posts"."options"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
     );

--- a/src/shared/migrations/1624449896646-add-user-entity-with-relations.ts
+++ b/src/shared/migrations/1624449896646-add-user-entity-with-relations.ts
@@ -1,0 +1,77 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import { POSTS_SCHEMA } from '../entity.model';
+
+export class addUserEntityWithRelations1624449896646
+  implements MigrationInterface {
+  name = 'addUserEntityWithRelations1624449896646';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" DROP CONSTRAINT "FK_26c647863c296d49e748b5ef98f"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" RENAME COLUMN "user_id" TO "userId"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."posts" RENAME COLUMN "user_id" TO "userId"`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "${POSTS_SCHEMA}"."users" ("id" SERIAL NOT NULL, "uuid" uuid NOT NULL, "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "name" character varying NOT NULL, "profile_pic" character varying NOT NULL, CONSTRAINT "PK_ddc86645bd3912d2b9a425880cd" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `COMMENT ON COLUMN "${POSTS_SCHEMA}"."votes"."id" IS NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" ADD CONSTRAINT "PK_7b73af10b8f22d092b684aa3ef4" PRIMARY KEY ("id")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."posts" ALTER COLUMN "userId" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `COMMENT ON COLUMN "${POSTS_SCHEMA}"."posts"."userId" IS NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" ADD CONSTRAINT "FK_3d4dc54f63e51860aecb575413d" FOREIGN KEY ("optionId") REFERENCES "${POSTS_SCHEMA}"."options"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" ADD CONSTRAINT "FK_0fd4decf372b9a2f1a463641057" FOREIGN KEY ("userId") REFERENCES "${POSTS_SCHEMA}"."users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."posts" ADD CONSTRAINT "FK_7992119133ff2c1c3d125ab3950" FOREIGN KEY ("userId") REFERENCES "${POSTS_SCHEMA}"."users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."posts" DROP CONSTRAINT "FK_7992119133ff2c1c3d125ab3950"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" DROP CONSTRAINT "FK_0fd4decf372b9a2f1a463641057"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" DROP CONSTRAINT "FK_3d4dc54f63e51860aecb575413d"`,
+    );
+    await queryRunner.query(
+      `COMMENT ON COLUMN "${POSTS_SCHEMA}"."posts"."userId" IS NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."posts" ALTER COLUMN "userId" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" DROP CONSTRAINT "PK_7b73af10b8f22d092b684aa3ef4"`,
+    );
+    await queryRunner.query(
+      `COMMENT ON COLUMN "${POSTS_SCHEMA}"."votes"."id" IS NULL`,
+    );
+    await queryRunner.query(`DROP TABLE "${POSTS_SCHEMA}"."users"`);
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."posts" RENAME COLUMN "userId" TO "user_id"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" RENAME COLUMN "userId" TO "user_id"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" ADD CONSTRAINT "FK_26c647863c296d49e748b5ef98f" FOREIGN KEY ("optionId") REFERENCES "pickify_posts"."options"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/src/shared/migrations/1624519345479-change-column-names-to-snake_case.ts
+++ b/src/shared/migrations/1624519345479-change-column-names-to-snake_case.ts
@@ -1,0 +1,115 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+import { POSTS_SCHEMA } from '../entity.model';
+
+export class changeColumnNamesToSnakeCase1624519345479
+  implements MigrationInterface {
+  name = 'changeColumnNamesToSnakeCase1624519345479';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" DROP CONSTRAINT "FK_3d4dc54f63e51860aecb575413d"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" DROP CONSTRAINT "FK_0fd4decf372b9a2f1a463641057"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."posts" DROP CONSTRAINT "FK_7992119133ff2c1c3d125ab3950"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."options_groups" DROP CONSTRAINT "FK_af348e9d2a36446a9e4a4254750"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."options" DROP CONSTRAINT "FK_cff2c5c22b420f553677f550126"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."posts" RENAME COLUMN "userId" TO "user_id"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."options_groups" RENAME COLUMN "postId" TO "post_id"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."options" RENAME COLUMN "optionsGroupId" TO "options_group_id"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" DROP COLUMN "userId"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" DROP COLUMN "optionId"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" ADD "option_id" integer`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" ADD "user_id" integer`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" ADD CONSTRAINT "FK_6f0a1ec5165835c82100f15d48a" FOREIGN KEY ("option_id") REFERENCES "${POSTS_SCHEMA}"."options"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" ADD CONSTRAINT "FK_ee5a54efe58165197a045d0ea27" FOREIGN KEY ("user_id") REFERENCES "${POSTS_SCHEMA}"."users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."posts" ADD CONSTRAINT "FK_0f0ad53f96850a0b96f94f80d6a" FOREIGN KEY ("user_id") REFERENCES "${POSTS_SCHEMA}"."users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."options_groups" ADD CONSTRAINT "FK_e207764c4f50f21bd050f0bb138" FOREIGN KEY ("post_id") REFERENCES "${POSTS_SCHEMA}"."posts"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."options" ADD CONSTRAINT "FK_2f21833a46f72eda5a36d1b07da" FOREIGN KEY ("options_group_id") REFERENCES "${POSTS_SCHEMA}"."options_groups"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."options" DROP CONSTRAINT "FK_2f21833a46f72eda5a36d1b07da"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."options_groups" DROP CONSTRAINT "FK_e207764c4f50f21bd050f0bb138"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."posts" DROP CONSTRAINT "FK_0f0ad53f96850a0b96f94f80d6a"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" DROP CONSTRAINT "FK_ee5a54efe58165197a045d0ea27"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" DROP CONSTRAINT "FK_6f0a1ec5165835c82100f15d48a"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" DROP COLUMN "user_id"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" DROP COLUMN "option_id"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" ADD "optionId" integer`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" ADD "userId" integer`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."options" RENAME COLUMN "options_group_id" TO "optionsGroupId"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."options_groups" RENAME COLUMN "post_id" TO "postId"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."posts" RENAME COLUMN "user_id" TO "userId"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."options" ADD CONSTRAINT "FK_cff2c5c22b420f553677f550126" FOREIGN KEY ("optionsGroupId") REFERENCES "${POSTS_SCHEMA}"."options_groups"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."options_groups" ADD CONSTRAINT "FK_af348e9d2a36446a9e4a4254750" FOREIGN KEY ("postId") REFERENCES "${POSTS_SCHEMA}"."posts"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."posts" ADD CONSTRAINT "FK_7992119133ff2c1c3d125ab3950" FOREIGN KEY ("userId") REFERENCES "${POSTS_SCHEMA}"."users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" ADD CONSTRAINT "FK_0fd4decf372b9a2f1a463641057" FOREIGN KEY ("userId") REFERENCES "${POSTS_SCHEMA}"."users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "${POSTS_SCHEMA}"."votes" ADD CONSTRAINT "FK_3d4dc54f63e51860aecb575413d" FOREIGN KEY ("optionId") REFERENCES "${POSTS_SCHEMA}"."options"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/src/votes/entities/vote.entity.ts
+++ b/src/votes/entities/vote.entity.ts
@@ -1,15 +1,21 @@
 import Model, { POSTS_SCHEMA } from '../../shared/entity.model';
-import { Column, Entity, ManyToOne } from 'typeorm';
+import { Entity, ManyToOne } from 'typeorm';
 import { Option } from '../../posts/entities/option.entity';
+import { User } from '../../posts/entities/user.entity';
 
 @Entity({ name: 'votes', schema: POSTS_SCHEMA })
 export class Vote extends Model {
+  // many to one relation with option entity
   @ManyToOne(() => Option, (option) => option.votes, {
     cascade: true,
     onDelete: 'CASCADE',
   })
   option: Option;
 
-  @Column()
-  user_id: number;
+  // many to one relation with user entity
+  @ManyToOne(() => User, (user) => user.votes, {
+    cascade: true,
+    onDelete: 'CASCADE',
+  })
+  user: User;
 }

--- a/src/votes/entities/vote.entity.ts
+++ b/src/votes/entities/vote.entity.ts
@@ -1,5 +1,5 @@
 import Model, { POSTS_SCHEMA } from '../../shared/entity.model';
-import { Entity, ManyToOne } from 'typeorm';
+import { Entity, JoinColumn, ManyToOne } from 'typeorm';
 import { Option } from '../../posts/entities/option.entity';
 import { User } from '../../posts/entities/user.entity';
 
@@ -10,6 +10,7 @@ export class Vote extends Model {
     cascade: true,
     onDelete: 'CASCADE',
   })
+  @JoinColumn({ name: 'option_id' })
   option: Option;
 
   // many to one relation with user entity
@@ -17,5 +18,6 @@ export class Vote extends Model {
     cascade: true,
     onDelete: 'CASCADE',
   })
+  @JoinColumn({ name: 'user_id' })
   user: User;
 }

--- a/src/votes/entities/votes.repository.ts
+++ b/src/votes/entities/votes.repository.ts
@@ -1,14 +1,15 @@
 import { EntityRepository, Repository } from 'typeorm';
 import { Vote } from './vote.entity';
 import { Option } from '../../posts/entities/option.entity';
+import { User } from 'src/posts/entities/user.entity';
 
 @EntityRepository(Vote)
 export class VoteRepository extends Repository<Vote> {
-  async addVote(option: Option, userId: number): Promise<void> {
+  async addVote(option: Option, user: User): Promise<void> {
     // Create vote and save it in DB
     const vote = this.create();
     vote.option = option;
-    vote.user_id = userId;
+    vote.user = user;
     await this.save(vote);
   }
 }

--- a/src/votes/votes.controller.spec.ts
+++ b/src/votes/votes.controller.spec.ts
@@ -29,7 +29,7 @@ describe('VotesController', () => {
     const params = { optionid: 'uuid' };
     it('should call service function with optionId', async () => {
       controller.addVote(params, { Authorization: '3' });
-      expect(mockService.addVote).toBeCalledWith(params.optionid, 3);
+      expect(mockService.addVote).toBeCalledWith(params.optionid, '3');
     });
     it('should return whatever service method returns', () => {
       const res = controller.addVote(params, { Authorization: '3' });

--- a/src/votes/votes.controller.ts
+++ b/src/votes/votes.controller.ts
@@ -19,6 +19,6 @@ export class VotesController {
     @Headers() headers: { Authorization: string },
   ): Promise<OptionsVotes[]> {
     const userId = headers.Authorization;
-    return this.votesService.addVote(params.optionid, +userId);
+    return this.votesService.addVote(params.optionid, userId);
   }
 }

--- a/src/votes/votes.module.ts
+++ b/src/votes/votes.module.ts
@@ -1,12 +1,19 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { OptionRepository } from 'src/posts/entities/option.repository';
+import { UserRepository } from 'src/posts/entities/user.repository';
 import { VoteRepository } from './entities/votes.repository';
 import { VotesController } from './votes.controller';
 import { VotesService } from './votes.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([VoteRepository, OptionRepository])],
+  imports: [
+    TypeOrmModule.forFeature([
+      VoteRepository,
+      OptionRepository,
+      UserRepository,
+    ]),
+  ],
   controllers: [VotesController],
   providers: [VotesService],
 })

--- a/src/votes/votes.service.spec.ts
+++ b/src/votes/votes.service.spec.ts
@@ -4,6 +4,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { UserRepository } from '../posts/entities/user.repository';
 import { Option } from '../posts/entities/option.entity';
 import { OptionRepository } from '../posts/entities/option.repository';
 import { VoteRepository } from './entities/votes.repository';
@@ -13,15 +14,22 @@ describe('VotesService', () => {
   let votesService: VotesService;
   let optionRepo: OptionRepository;
   let voteRepo: VoteRepository;
+  let userRepo: UserRepository;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [VotesService, VoteRepository, OptionRepository],
+      providers: [
+        VotesService,
+        VoteRepository,
+        OptionRepository,
+        UserRepository,
+      ],
     }).compile();
 
     votesService = module.get<VotesService>(VotesService);
     voteRepo = module.get<VoteRepository>(VoteRepository);
     optionRepo = module.get<OptionRepository>(OptionRepository);
+    userRepo = module.get<UserRepository>(UserRepository);
   });
 
   it('should be defined and have the necessarry methods', () => {
@@ -32,6 +40,8 @@ describe('VotesService', () => {
   describe('addVote method', () => {
     it('should add vote to option & return vote_count & ids of all options in the group', async () => {
       // data
+      const userId = 'test-user-uuid';
+      const foundUser = { uuid: userId };
       const expectedResponse = [
         { votes_count: 3, optionId: 'option1-test-uuid' },
         { votes_count: 0, optionId: 'option2-test-uuid' },
@@ -51,13 +61,13 @@ describe('VotesService', () => {
           ],
         },
         votes: [
-          { id: 1, user_id: 1 },
-          { id: 2, user_id: 3 },
+          { id: 1, user: { uuid: 'test-user1-uuid' } },
+          { id: 2, user: { uuid: 'test-user2-uuid' } },
         ],
       };
 
       // mocks
-      optionRepo.findOptionById = jest.fn().mockImplementation(() => {
+      optionRepo.findDetailedOptionById = jest.fn().mockImplementation(() => {
         return Promise.resolve(optionInDB);
       });
 
@@ -70,25 +80,33 @@ describe('VotesService', () => {
           return Promise.resolve(option);
         });
 
+      userRepo.findOne = jest.fn().mockResolvedValue(foundUser);
+
       // assertions
-      expect(votesService.addVote('option1-test-uuid', 2)).resolves.toEqual(
-        expectedResponse,
-      );
+      expect(
+        votesService.addVote('option1-test-uuid', userId),
+      ).resolves.toEqual(expectedResponse);
     });
     it('should throw not found error if option not found', () => {
+      // data
+      const userId = 'test-user-uuid';
+
       // mocks
-      optionRepo.findOptionById = jest.fn().mockImplementation(() => {
+      optionRepo.findDetailedOptionById = jest.fn().mockImplementation(() => {
         return Promise.resolve(undefined);
       });
 
       // assertions
-      expect(votesService.addVote('option1-test-uuid', 2)).rejects.toThrowError(
+      expect(
+        votesService.addVote('option1-test-uuid', userId),
+      ).rejects.toThrowError(
         new NotFoundException('Option with id:option1-test-uuid not found'),
       );
     });
 
     it('should throw locked error if post is not created yet', () => {
       // data
+      const userId = 'test-user-uuid';
       const optionInDB = {
         id: 1,
         uuid: 'option1-test-uuid',
@@ -104,18 +122,20 @@ describe('VotesService', () => {
           ],
         },
         votes: [
-          { id: 1, user_id: 1 },
-          { id: 2, user_id: 3 },
+          { id: 1, user: { uuid: userId } },
+          { id: 2, user: { uuid: 'test-user2-uuid' } },
         ],
       };
 
       // mocks
-      optionRepo.findOptionById = jest.fn().mockImplementation(() => {
+      optionRepo.findDetailedOptionById = jest.fn().mockImplementation(() => {
         return Promise.resolve(optionInDB);
       });
 
       // assertions
-      expect(votesService.addVote('option1-test-uuid', 2)).rejects.toThrowError(
+      expect(
+        votesService.addVote('option1-test-uuid', userId),
+      ).rejects.toThrowError(
         new HttpException(
           'Post:post-test-uuid with option:option1-test-uuid still under creation...',
           423,
@@ -125,6 +145,8 @@ describe('VotesService', () => {
 
     it('should throw conflict error if user voted before', () => {
       // data
+      const userId = 'test-user-uuid';
+      const foundUser = { uuid: userId };
       const optionInDB = {
         id: 1,
         uuid: 'option1-test-uuid',
@@ -140,24 +162,32 @@ describe('VotesService', () => {
           ],
         },
         votes: [
-          { id: 1, user_id: 1 },
-          { id: 2, user_id: 3 },
+          { id: 1, user: { uuid: userId } },
+          { id: 2, user: { uuid: 'test-user2-uuid' } },
         ],
       };
 
       // mocks
-      optionRepo.findOptionById = jest.fn().mockImplementation(() => {
+      optionRepo.findDetailedOptionById = jest.fn().mockImplementation(() => {
         return Promise.resolve(optionInDB);
       });
 
+      userRepo.findOne = jest.fn().mockResolvedValue(foundUser);
+
       // assertions
-      expect(votesService.addVote('option1-test-uuid', 1)).rejects.toThrowError(
+      expect(
+        votesService.addVote('option1-test-uuid', userId),
+      ).rejects.toThrowError(
         new ConflictException('User has already voted for this option'),
       );
     });
 
     it('should call vote.Repository.addVote with needed parameters', async () => {
       // data
+      const userId = 'test-user-uuid';
+
+      const foundUser = { uuid: userId };
+
       const optionInDB = {
         id: 1,
         uuid: 'option1-test-uuid',
@@ -172,8 +202,8 @@ describe('VotesService', () => {
           ],
         },
         votes: [
-          { id: 1, user_id: 1 },
-          { id: 2, user_id: 3 },
+          { id: 1, user: { uuid: 'test-user1-uuid' } },
+          { id: 2, user: { uuid: 'test-user2-uuid' } },
         ],
       };
 
@@ -192,10 +222,8 @@ describe('VotesService', () => {
         },
       };
 
-      const userId = 2;
-
       // mocks
-      optionRepo.findOptionById = jest.fn().mockImplementation(() => {
+      optionRepo.findDetailedOptionById = jest.fn().mockImplementation(() => {
         return Promise.resolve(optionInDB);
       });
 
@@ -208,10 +236,12 @@ describe('VotesService', () => {
           return Promise.resolve(option);
         });
 
-      // calls
+      userRepo.findOne = jest.fn().mockResolvedValue(foundUser);
+
+      // actions
       await votesService.addVote('option1-test-uuid', userId);
       // assertions
-      expect(voteRepo.addVote).toBeCalledWith(passedOption, userId);
+      expect(voteRepo.addVote).toBeCalledWith(passedOption, foundUser);
     });
   });
 });


### PR DESCRIPTION
Closes #86 

#### This PR updates the response of `GET /api/posts` & `GET /api/:postid` to add the user details. The following has been done:
- add post entity + repository
- add many-to-one relation between `post` & `vote` entities and user entity
- remove the column `user_id` from `post` & 'vote' entites
- add migration file for the changes
- update the posts module, controller, service, repository and options repository to handle the new change
- update the tests of posts controller & posts service
- update the votesmodule, controller, service, and repository to handle the changes
- update the tests of votes controller & votes service
- update the database queries & http client examples