### PR TITLE
Sort options groups

### DIFF
--- a/examples/examples.http
+++ b/examples/examples.http
@@ -1,4 +1,4 @@
-@postId = 5e7c2be5-922d-4ad1-94c0-23b820e4529d
+@postId = 215e4cf9-538a-4b8c-aaa9-50720a2b2341
 @groupId = 098836f8-aa60-461b-9f59-1d769001ec88
 @optionId = bdf0c500-f42c-47ba-87bb-d20bf80b74b5
 @userId = 3ad4e0f5-1787-46fa-851f-d7dddbfaf2c3
@@ -95,16 +95,41 @@ Authorization: Bearer {{userId}}
 {   
     "groups": [
         {
-            "name": "NAME: latest post",
+            "name": "group1",
             "options": [
                 {
-                    "body":"option 1 body"
+                    "body":"g1o1"
                 },
                 {
-                    "body":"option 2 body"
+                    "body":"g1o2"
                 },
                 {
-                    "body":"option 3 body"
+                    "body":"g1o3"
+                }
+            ]
+        },
+        {
+            "name": "group2",
+            "options": [
+                {
+                    "body":"g2o1"
+                },
+                {
+                    "body":"g2o2"
+                }
+            ]
+        },
+        {
+            "name": "group3",
+            "options": [
+                {
+                    "body":"g3o1"
+                },
+                {
+                    "body":"g3o2"
+                },
+                {
+                    "body":"g3o3"
                 }
             ]
         }

--- a/src/posts/entities/optionsGroup.entity.ts
+++ b/src/posts/entities/optionsGroup.entity.ts
@@ -9,6 +9,9 @@ export class OptiosnGroup extends Model {
   @Column()
   name: string;
 
+  @Column({ default: 0 })
+  order: number;
+
   // one to many relation with option entity
   @OneToMany(() => Option, (option) => option.optionsGroup)
   options: Option[];

--- a/src/posts/entities/optionsGroup.repository.ts
+++ b/src/posts/entities/optionsGroup.repository.ts
@@ -10,10 +10,13 @@ export class OptionsGroupRepository extends Repository<OptiosnGroup> {
   public async createGroup(
     post: Post,
     groupDto: OptionsGroupDto,
+    groupOrder: number,
   ): Promise<OptiosnGroup> {
     const group = this.create();
+
     group.name = groupDto.name;
     group.post = post;
+    group.order = groupOrder;
 
     return await this.save(group);
   }

--- a/src/posts/entities/post.repository.ts
+++ b/src/posts/entities/post.repository.ts
@@ -46,6 +46,7 @@ export class PostRepository extends Repository<Post> {
       .leftJoin('post.user', 'user')
       .orderBy({
         'post.created_at': 'DESC',
+        'group.order': 'ASC',
         'option.order': 'ASC',
       })
       .getMany();

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -119,10 +119,16 @@ export class PostsService {
       throw new UnauthorizedException('Unauthorized');
     }
 
+    let groupOrder = 0;
+
     // Add each group to DB along with its options
     for (const group of groupsCreationDto.groups) {
       // create group
-      const createdGroup = await this.groupRepository.createGroup(post, group);
+      const createdGroup = await this.groupRepository.createGroup(
+        post,
+        group,
+        groupOrder++,
+      );
 
       // create options
       const options = await this.optionRepository.createBulk(

--- a/src/shared/migrations/1624648980278-update_optionsGroupsEntity.ts
+++ b/src/shared/migrations/1624648980278-update_optionsGroupsEntity.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class updateOptionsGroupsEntity1624648980278
+  implements MigrationInterface {
+  name = 'updateOptionsGroupsEntity1624648980278';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "pickify_posts"."options_groups" ADD "order" integer NOT NULL DEFAULT '0'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "pickify_posts"."options_groups" DROP COLUMN "order"`,
+    );
+  }
+}


### PR DESCRIPTION
Closes #91 

- Add order column for the options_groups to be able to sort the groups related to a single post.
- Retrieve the optionsGroups sorted in the order as specified by the user.