### PR TITLE
Add rabbitMQ to docker-compose and add it with db to the prestart script

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,7 @@ services:
       PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
       - /home/$USER/docker_pg_data:/var/lib/postgresql/data
+      
   app:
     image: microservice-template:latest
     container_name: microservice-template
@@ -17,3 +18,13 @@ services:
       - .development.env
     volumes:
       - /pickly-backend-template:$PWD/pickly-backend-template
+  
+  rabbitmq:
+    image: rabbitmq:3-management-alpine
+    container_name: rabbitmq
+    network_mode: host
+    environment:
+      RABBITMQ_DEFAULT_USER: admin
+      RABBITMQ_DEFAULT_PASS: admin
+      RABBITMQ_URL: amqp://admin:admin@localhost:5672
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,16 +9,7 @@ services:
       PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
       - /home/$USER/docker_pg_data:/var/lib/postgresql/data
-      
-  app:
-    image: microservice-template:latest
-    container_name: microservice-template
-    network_mode: host
-    env_file:
-      - .development.env
-    volumes:
-      - /pickly-backend-template:$PWD/pickly-backend-template
-  
+        
   rabbitmq:
     image: rabbitmq:3-management-alpine
     container_name: rabbitmq

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
-    "prestart:dev": "docker-compose up -d db rabbitmq",
+    "prestart:dev": "docker-compose up -d",
     "start:dev": "NODE_ENV=development nest start --watch",
     "start:production": "NODE_ENV=production nest start --watch",
     "start:debug": "nest start --debug --watch",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
-    "prestart:dev": "docker-compose up -d db",
+    "prestart:dev": "docker-compose up -d db rabbitmq",
     "start:dev": "NODE_ENV=development nest start --watch",
     "start:production": "NODE_ENV=production nest start --watch",
     "start:debug": "nest start --debug --watch",


### PR DESCRIPTION
Closes #137 

- Add rabbitMQ to docker-compose and add it with db to the prestart script.