### PR TITLE
Make option body not required

### DIFF
--- a/examples/examples.http
+++ b/examples/examples.http
@@ -1,7 +1,7 @@
-@postId = 6c22e70b-33c5-406c-8cae-728b52530798
+@postId = 1f56de9c-5b76-494e-b02b-de07574348d5
 @groupId = 6ffb799f-a017-483c-b364-dd10a6e95252
 @optionId = ec8d4b30-ad98-44fc-a51d-d57b28ec4a2b
-@userId = 3ad4e0f5-1787-46fa-851f-d7dddbfaf2c3
+@userId = 6c1f812c-2fca-4c05-8cec-2a9eb56c35d0
 
 // POST /api/posts
 //////////////////
@@ -12,7 +12,7 @@ Authorization: Bearer {{userId}}
 {
     "type": "text_poll",
     "is_hidden": false,
-    "media_count": 3
+    "media_count": 0
 }
 
 ###
@@ -49,8 +49,8 @@ Authorization: Bearer {{userId}}
 {   
     "caption": "post caption",
     "type": "text_poll",
-    "is_hidden": "false",
-    "media_count": 3
+    "is_hidden": false,
+    "media_count": 0
 }
 
 ##################
@@ -109,17 +109,6 @@ Authorization: Bearer {{userId}}
                 },
                 {
                     "body":"g1o3"
-                }
-            ]
-        },
-        {
-            "name": "group2",
-            "options": [
-                {
-                    "body":"g2o1"
-                },
-                {
-                    "body":"g2o2"
                 }
             ]
         },

--- a/src/posts/dto/optionGroupCreation.dto.ts
+++ b/src/posts/dto/optionGroupCreation.dto.ts
@@ -7,8 +7,9 @@ import {
 } from 'class-validator';
 
 export class OptionDto {
+  @IsOptional()
   @IsString()
-  body: string;
+  body?: string;
 }
 
 export class OptionsGroupDto {

--- a/src/posts/entities/option.entity.ts
+++ b/src/posts/entities/option.entity.ts
@@ -6,7 +6,7 @@ import { Media } from '../../media/entities/media.entity';
 
 @Entity({ name: 'options', schema: POSTS_SCHEMA })
 export class Option extends Model {
-  @Column()
+  @Column({ nullable: true })
   body: string;
 
   @Column()

--- a/src/shared/migrations/1626219362732-update_makeOptionBodyNotRequired.ts
+++ b/src/shared/migrations/1626219362732-update_makeOptionBodyNotRequired.ts
@@ -1,0 +1,24 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class updateMakeOptionBodyNotRequired1626219362732
+  implements MigrationInterface {
+  name = 'updateMakeOptionBodyNotRequired1626219362732';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "pickify_posts"."options" ALTER COLUMN "body" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `COMMENT ON COLUMN "pickify_posts"."options"."body" IS NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `COMMENT ON COLUMN "pickify_posts"."options"."body" IS NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "pickify_posts"."options" ALTER COLUMN "body" SET NOT NULL`,
+    );
+  }
+}

--- a/src/shared/migrations/1626219362732-update_makeOptionBodyNotRequired.ts
+++ b/src/shared/migrations/1626219362732-update_makeOptionBodyNotRequired.ts
@@ -1,4 +1,5 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
+import { POSTS_SCHEMA } from '../entity.model';
 
 export class updateMakeOptionBodyNotRequired1626219362732
   implements MigrationInterface {
@@ -6,19 +7,19 @@ export class updateMakeOptionBodyNotRequired1626219362732
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE "pickify_posts"."options" ALTER COLUMN "body" DROP NOT NULL`,
+      `ALTER TABLE "${POSTS_SCHEMA}"."options" ALTER COLUMN "body" DROP NOT NULL`,
     );
     await queryRunner.query(
-      `COMMENT ON COLUMN "pickify_posts"."options"."body" IS NULL`,
+      `COMMENT ON COLUMN "${POSTS_SCHEMA}"."options"."body" IS NULL`,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `COMMENT ON COLUMN "pickify_posts"."options"."body" IS NULL`,
+      `COMMENT ON COLUMN "${POSTS_SCHEMA}"."options"."body" IS NULL`,
     );
     await queryRunner.query(
-      `ALTER TABLE "pickify_posts"."options" ALTER COLUMN "body" SET NOT NULL`,
+      `ALTER TABLE "${POSTS_SCHEMA}"."options" ALTER COLUMN "body" SET NOT NULL`,
     );
   }
 }


### PR DESCRIPTION
Closes #119 

- Make `option.body` to be optional/not_required.
- Make necessary changes and updates for the migration files.