### PR TITLE
Apply auth

### DIFF
--- a/src/posts/posts.controller.spec.ts
+++ b/src/posts/posts.controller.spec.ts
@@ -85,7 +85,7 @@ describe('PostsController', () => {
   describe('createOptionGroup function', () => {
     it('should call service.createOptionGroup with proper parameters and return its return', async () => {
       // data
-      const headers = { Authorization: '3' };
+      const req = { user: { uuid: 'user-uuid' } } as ExtendedRequest;
       const param: PostIdParam = { postid: 'test postId' };
       const dto: OptionsGroupCreationDto = {
         groups: [
@@ -97,13 +97,13 @@ describe('PostsController', () => {
       };
 
       // actions
-      const data = await controller.createOptionGroup(param, dto, headers);
+      const data = await controller.createOptionGroup(param, dto, req);
 
       // assertions
       expect(service.createOptionGroup).toBeCalledWith(
         param.postid,
         dto,
-        headers.Authorization,
+        req.user,
       );
       expect(data).toEqual('test creating groups');
     });

--- a/src/posts/posts.controller.spec.ts
+++ b/src/posts/posts.controller.spec.ts
@@ -131,19 +131,16 @@ describe('PostsController', () => {
   describe('deletePost function', () => {
     it('does not return anything', async () => {
       const params = { postid: 'uuid' };
-      const headers = { Authorization: '3' };
-      const res = await controller.deletePost(params, headers);
+      const req = { user: { uuid: 'user-uuid' } } as ExtendedRequest;
+      const res = await controller.deletePost(params, req);
       expect(res).toBeUndefined();
     });
 
     it('should call service function with postid and authroization header', async () => {
       const params = { postid: 'uuid' };
-      const headers = { Authorization: '3' };
-      await controller.deletePost(params, headers);
-      expect(service.deletePost).toBeCalledWith(
-        params.postid,
-        headers.Authorization,
-      );
+      const req = { user: { uuid: 'user-uuid' } } as ExtendedRequest;
+      await controller.deletePost(params, req);
+      expect(service.deletePost).toBeCalledWith(params.postid, req.user);
     });
   });
 });

--- a/src/posts/posts.controller.spec.ts
+++ b/src/posts/posts.controller.spec.ts
@@ -5,6 +5,7 @@ import { PostsController } from './posts.controller';
 import { PostsService } from './posts.service';
 import { FlagPostFinishedDto } from './dto/flag-post-finished';
 import { PostCreationDto } from './dto/postCreation.dto';
+import { ExtendedRequest } from '../shared/interfaces/expressRequest';
 
 describe('PostsController', () => {
   let controller: PostsController;
@@ -57,14 +58,14 @@ describe('PostsController', () => {
   describe('getAllPosts function', () => {
     it('should return object with array of posts and post count', async () => {
       // data
-      const headers = { Authorization: 'test-user-uuid' };
+      const req = { user: { uuid: 'user-uuid' } } as ExtendedRequest;
 
       // actions
-      const result = await controller.getAllPosts(headers);
+      const result = await controller.getAllPosts(req);
 
       // assertions
       expect(result).toEqual({ postCount: 1, posts: [{ uuid: 'post1-uuid' }] });
-      expect(service.getAllPosts).toHaveBeenCalledWith(headers.Authorization);
+      expect(service.getAllPosts).toHaveBeenCalledWith(req.user);
     });
   });
 

--- a/src/posts/posts.controller.spec.ts
+++ b/src/posts/posts.controller.spec.ts
@@ -114,16 +114,16 @@ describe('PostsController', () => {
       // data
       const dto: FlagPostFinishedDto = { finished: true };
       const params: PostIdParam = { postid: '23242' };
-      const headers = { Authorization: '3' };
+      const req = { user: { uuid: 'user-uuid' } } as ExtendedRequest;
 
       // actions
-      await controller.flagPost(params, dto, headers);
+      await controller.flagPost(params, dto, req);
 
       // assertions
       expect(service.flagPost).toBeCalledWith(
         params.postid,
         dto.finished,
-        headers.Authorization,
+        req.user,
       );
     });
   });

--- a/src/posts/posts.controller.spec.ts
+++ b/src/posts/posts.controller.spec.ts
@@ -34,6 +34,7 @@ describe('PostsController', () => {
 
   describe('createPost function', () => {
     it('should return a string', async () => {
+      // data
       const dto: PostCreationDto = {
         caption: 'test dto',
         type: 'text_poll',
@@ -41,14 +42,15 @@ describe('PostsController', () => {
         media_count: 3,
       };
 
-      const headers = { Authorization: '3' };
+      const req: any = { user: { uuid: 'user-uuid' } };
 
-      const result = await controller.createPost(dto, headers);
+      // actions
+      const result = await controller.createPost(dto, req);
 
+      // assertions
       expect(result).toEqual({ uuid: 'test id' });
-
       expect(service.createPost).toBeCalledTimes(1);
-      expect(service.createPost).toBeCalledWith(dto, headers.Authorization);
+      expect(service.createPost).toBeCalledWith(dto, req.user);
     });
   });
 

--- a/src/posts/posts.controller.spec.ts
+++ b/src/posts/posts.controller.spec.ts
@@ -70,18 +70,15 @@ describe('PostsController', () => {
   });
 
   describe('getSinglePost function', () => {
-    it('should throw not implemented', async () => {
+    it('Should return what service.getSinglePost returns', async () => {
       // data
-      const headers = { Authorization: 'test-user-uuid' };
+      const req = { user: { uuid: 'user-uuid' } } as ExtendedRequest;
       const params = { postid: 'post1-id' };
 
       // actions
-      const result = await controller.getSinglePost(params, headers);
+      const result = await controller.getSinglePost(params, req);
       expect(result).toEqual({ id: 'post1-id' });
-      expect(service.getSinglePost).toBeCalledWith(
-        params.postid,
-        headers.Authorization,
-      );
+      expect(service.getSinglePost).toBeCalledWith(params.postid, req.user);
     });
   });
 

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -8,8 +8,10 @@ import {
   Param,
   Patch,
   Post,
+  Request,
   UseFilters,
 } from '@nestjs/common';
+import { ExtendedRequest } from 'src/shared/interfaces/expressRequest';
 import * as winston from 'winston';
 import { winstonLoggerOptions } from '../logging/winston.options';
 import { ValidationExceptionFilter } from '../shared/exception-filters/validation-exception.filter';
@@ -33,10 +35,9 @@ export class PostsController {
   @Post('/')
   createPost(
     @Body() postCreationDto: PostCreationDto,
-    @Headers() headers: { Authorization: string },
+    @Request() req: ExtendedRequest,
   ): Promise<PostCreationInterface> {
-    const userId = headers.Authorization;
-    return this.postsService.createPost(postCreationDto, userId);
+    return this.postsService.createPost(postCreationDto, req.user);
   }
 
   @Get('/')

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -48,10 +48,9 @@ export class PostsController {
   @Get('/:postid')
   getSinglePost(
     @Param() params: PostIdParam,
-    @Headers() headers: { Authorization: string },
+    @Request() req: ExtendedRequest,
   ): Promise<GetPost> {
-    const userId = headers.Authorization;
-    return this.postsService.getSinglePost(params.postid, userId);
+    return this.postsService.getSinglePost(params.postid, req.user);
   }
 
   @Post('/:postid/groups')

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -57,13 +57,12 @@ export class PostsController {
   async createOptionGroup(
     @Param() params: PostIdParam,
     @Body() createGroupsDto: OptionsGroupCreationDto,
-    @Headers() headers: { Authorization: string },
+    @Request() req: ExtendedRequest,
   ): Promise<OptionsGroups> {
-    const userId = headers.Authorization;
     const createdGroups = await this.postsService.createOptionGroup(
       params.postid,
       createGroupsDto,
-      userId,
+      req.user,
     );
     return createdGroups;
   }

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -87,9 +87,8 @@ export class PostsController {
   @HttpCode(204)
   async deletePost(
     @Param() params: PostIdParam,
-    @Headers() headers: { Authorization: string },
+    @Request() req: ExtendedRequest,
   ) {
-    const userId = headers.Authorization;
-    await this.postsService.deletePost(params.postid, userId);
+    await this.postsService.deletePost(params.postid, req.user);
   }
 }

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -73,13 +73,12 @@ export class PostsController {
   async flagPost(
     @Param() params: PostIdParam,
     @Body() flagPostDto: FlagPostFinishedDto,
-    @Headers() headers: { Authorization: string },
+    @Request() req: ExtendedRequest,
   ): Promise<void> {
-    const userId = headers.Authorization;
     await this.postsService.flagPost(
       params.postid,
       flagPostDto.finished,
-      userId,
+      req.user,
     );
   }
 

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -41,11 +41,8 @@ export class PostsController {
   }
 
   @Get('/')
-  async getAllPosts(
-    @Headers() headers: { Authorization: string },
-  ): Promise<Posts> {
-    const userId = headers.Authorization;
-    return await this.postsService.getAllPosts(userId);
+  async getAllPosts(@Request() req: ExtendedRequest): Promise<Posts> {
+    return await this.postsService.getAllPosts(req.user);
   }
 
   @Get('/:postid')

--- a/src/posts/posts.service.spec.ts
+++ b/src/posts/posts.service.spec.ts
@@ -226,7 +226,6 @@ describe('PostsService', () => {
         .fn()
         .mockResolvedValueOnce({ uuid: 'created-post-uuid' });
 
-
       // action
       await service.createPost(dto, user);
 
@@ -421,7 +420,12 @@ describe('PostsService', () => {
   describe('getSinglePost function', () => {
     it('Should return post with vote_count for all options if user is post owner', async () => {
       // data
-      const userId = 'test-post-owner-uuid';
+      const user = {
+        uuid: 'user-uuid',
+        name: 'test',
+        profile_pic: 'test-url',
+      } as User;
+
       const postInDB = {
         uuid: 'test-post-uuid',
         ready: true,
@@ -430,7 +434,7 @@ describe('PostsService', () => {
         created_at: getNow().toDate(),
         type: 'text poll',
         user: {
-          uuid: userId,
+          uuid: user.uuid,
           name: 'test',
           profile_pic: 'test-url',
         },
@@ -515,7 +519,7 @@ describe('PostsService', () => {
       postRepo.getDetailedPostById = jest.fn().mockResolvedValueOnce(postInDB);
 
       // actions
-      const result = await service.getSinglePost(postId, userId);
+      const result = await service.getSinglePost(postId, user);
 
       // assertions
       expect(result).toEqual(expectedPost);
@@ -523,7 +527,12 @@ describe('PostsService', () => {
 
     it('Should return same media found in DB', async () => {
       // data
-      const userId = 'test-post-owner-uuid';
+      const user = {
+        uuid: 'user-uuid',
+        name: 'test',
+        profile_pic: 'test-url',
+      } as User;
+
       const postInDB = {
         uuid: 'test-post-uuid',
         ready: true,
@@ -532,7 +541,7 @@ describe('PostsService', () => {
         created_at: getNow().toDate(),
         type: 'text poll',
         user: {
-          uuid: userId,
+          uuid: user.uuid,
           name: 'test',
           profile_pic: 'test-url',
         },
@@ -575,6 +584,7 @@ describe('PostsService', () => {
           },
         ],
       };
+
       const expectedPost = {
         id: postInDB.uuid,
         caption: postInDB.caption,
@@ -617,7 +627,7 @@ describe('PostsService', () => {
       postRepo.getDetailedPostById = jest.fn().mockResolvedValueOnce(postInDB);
 
       // actions
-      const result = await service.getSinglePost(postId, userId);
+      const result = await service.getSinglePost(postId, user);
 
       // assertions
       expect(result).toEqual(expectedPost);
@@ -625,7 +635,12 @@ describe('PostsService', () => {
 
     it('Should return post without vote_count for any option in the group if user has not voted in that group', async () => {
       // data
-      const userId = 'user1';
+      const user = {
+        uuid: 'user1',
+        name: 'test',
+        profile_pic: 'test-url',
+      } as User;
+
       const postInDB = {
         uuid: 'test-post-uuid',
         ready: true,
@@ -713,7 +728,7 @@ describe('PostsService', () => {
       postRepo.getDetailedPostById = jest.fn().mockResolvedValueOnce(postInDB);
 
       // actions
-      const result = await service.getSinglePost(postId, userId);
+      const result = await service.getSinglePost(postId, user);
 
       // assertions
       expect(result).toEqual(expectedPost);
@@ -721,7 +736,12 @@ describe('PostsService', () => {
 
     it('Should return post with vote_count for all options ONLY in the group user voted in', async () => {
       // data
-      const userId = 'user1';
+      const user = {
+        uuid: 'user1',
+        name: 'test',
+        profile_pic: 'test-url',
+      } as User;
+
       const postInDB = {
         uuid: 'test-post-uuid',
         ready: true,
@@ -847,7 +867,7 @@ describe('PostsService', () => {
       postRepo.getDetailedPostById = jest.fn().mockResolvedValueOnce(postInDB);
 
       // actions
-      const result = await service.getSinglePost(postId, userId);
+      const result = await service.getSinglePost(postId, user);
 
       // assertions
       expect(result).toEqual(expectedPost);
@@ -855,7 +875,12 @@ describe('PostsService', () => {
 
     it('Should return post without user details if he is not post owner and is_hidden=true', async () => {
       // data
-      const userId = 'user1';
+      const user = {
+        uuid: 'user1',
+        name: 'test',
+        profile_pic: 'test-url',
+      } as User;
+
       const postInDB = {
         uuid: 'test-post-uuid',
         ready: true,
@@ -918,7 +943,7 @@ describe('PostsService', () => {
       postRepo.getDetailedPostById = jest.fn().mockResolvedValueOnce(postInDB);
 
       // actions
-      const result = await service.getSinglePost(postId, userId);
+      const result = await service.getSinglePost(postId, user);
 
       // assertions
       expect(result).toEqual(expectedPost);
@@ -926,14 +951,19 @@ describe('PostsService', () => {
 
     it('should throw error if post not found', () => {
       // data
-      const userId = 'test-user-uuid';
+      const user = {
+        uuid: 'user-uuid',
+        name: 'test',
+        profile_pic: 'test-url',
+      } as User;
+
       const postId = 'test-post-uuid';
 
       // mocks
       postRepo.getDetailedPostById = jest.fn().mockResolvedValueOnce(undefined);
 
       // actions
-      const result = service.getSinglePost(postId, userId);
+      const result = service.getSinglePost(postId, user);
 
       // assertions
       expect(result).rejects.toThrowError(
@@ -943,7 +973,12 @@ describe('PostsService', () => {
 
     it('should throw error if post not ready yet', () => {
       // data
-      const userId = 'test-user-uuid';
+      const user = {
+        uuid: 'user-uuid',
+        name: 'test',
+        profile_pic: 'test-url',
+      } as User;
+
       const postInDB = {
         uuid: 'test-post-uuid',
         ready: false,
@@ -971,7 +1006,7 @@ describe('PostsService', () => {
       postRepo.getDetailedPostById = jest.fn().mockResolvedValueOnce(postInDB);
 
       // actions
-      const result = service.getSinglePost(postId, userId);
+      const result = service.getSinglePost(postId, user);
 
       // assertions
       expect(result).rejects.toThrowError(

--- a/src/posts/posts.service.spec.ts
+++ b/src/posts/posts.service.spec.ts
@@ -1023,8 +1023,8 @@ describe('PostsService', () => {
       // data
       const flag = true;
       const postid = 'test-post-uuid';
-      const userId = 'test-user-uuid';
-      const foundPost = { id: 1, user: { uuid: userId } };
+      const user = { uuid: 'user-uuid' } as User;
+      const foundPost = { id: 1, user: { uuid: user.uuid } };
 
       // mocks
       postRepo.getPostById = jest.fn().mockResolvedValueOnce(foundPost);
@@ -1032,7 +1032,7 @@ describe('PostsService', () => {
       postRepo.flagPostCreation = jest.fn().mockResolvedValueOnce(undefined);
 
       // action
-      const data = service.flagPost(postid, flag, userId);
+      const data = service.flagPost(postid, flag, user);
 
       // assertions
       expect(data).resolves.toBeUndefined();
@@ -1042,8 +1042,8 @@ describe('PostsService', () => {
       // data
       const flag = true;
       const postid = 'test-post-uuid';
-      const userId = 'test-user-uuid';
-      const foundPost = { id: 1, user: { uuid: userId } };
+      const user = { uuid: 'user-uuid' } as User;
+      const foundPost = { id: 1, user: { uuid: user.uuid } };
 
       // mocks
       postRepo.getPostById = jest.fn().mockResolvedValueOnce(foundPost);
@@ -1051,7 +1051,7 @@ describe('PostsService', () => {
       postRepo.flagPostCreation = jest.fn().mockResolvedValueOnce(undefined);
 
       // action
-      await service.flagPost(postid, flag, userId);
+      await service.flagPost(postid, flag, user);
 
       // assertions
       expect(postRepo.getPostById).toBeCalledWith(postid);
@@ -1061,7 +1061,7 @@ describe('PostsService', () => {
       // data
       const flag = true;
       const postid = 'test-post-uuid';
-      const userId = '3';
+      const user = { uuid: 'user-uuid' } as User;
 
       // mocks
       postRepo.getPostById = jest.fn().mockResolvedValueOnce(undefined);
@@ -1069,7 +1069,7 @@ describe('PostsService', () => {
       postRepo.flagPostCreation = jest.fn().mockResolvedValueOnce(undefined);
 
       // action
-      const data = service.flagPost(postid, flag, userId);
+      const data = service.flagPost(postid, flag, user);
 
       // assertions
       expect(data).rejects.toThrowError(
@@ -1081,8 +1081,8 @@ describe('PostsService', () => {
       // data
       const flag = true;
       const postid = 'test-post-uuid';
-      const userId = 'user-owns-post';
-      const foundPost = { id: 1, user: { uuid: 'user-dont-own-post' } };
+      const user = { uuid: 'user-uuid' } as User;
+      const foundPost = { id: 1, user: { uuid: 'user-doesnt-own-post' } };
 
       // mocks
       postRepo.getPostById = jest.fn().mockResolvedValueOnce(foundPost);
@@ -1090,7 +1090,7 @@ describe('PostsService', () => {
       postRepo.flagPostCreation = jest.fn().mockResolvedValueOnce(undefined);
 
       // action
-      const data = service.flagPost(postid, flag, userId);
+      const data = service.flagPost(postid, flag, user);
 
       // assertions
       expect(data).rejects.toThrowError(
@@ -1102,8 +1102,8 @@ describe('PostsService', () => {
       // data
       const flag = true;
       const postid = 'test-post-uuid';
-      const userId = 'test-user-uuid';
-      const foundPost = { id: 1, user: { uuid: userId } };
+      const user = { uuid: 'user-uuid' } as User;
+      const foundPost = { id: 1, user: { uuid: user.uuid } };
 
       // mocks
       postRepo.getPostById = jest.fn().mockResolvedValueOnce(foundPost);
@@ -1111,7 +1111,7 @@ describe('PostsService', () => {
       postRepo.flagPostCreation = jest.fn().mockResolvedValueOnce(undefined);
 
       // action
-      await service.flagPost(postid, flag, userId);
+      await service.flagPost(postid, flag, user);
 
       // assertions
       expect(postRepo.flagPostCreation).toBeCalledWith(flag, foundPost);

--- a/src/posts/posts.service.spec.ts
+++ b/src/posts/posts.service.spec.ts
@@ -239,7 +239,11 @@ describe('PostsService', () => {
   describe('getAllPosts function ', () => {
     it('should return object contains postsCount and array of posts', async () => {
       // data
-      const userId = 'user1';
+      const user = {
+        uuid: 'user-id',
+        name: 'test',
+        profile_pic: 'test-url',
+      } as User;
       const postInDB = {
         uuid: 'test-post-uuid',
         ready: true,
@@ -248,7 +252,7 @@ describe('PostsService', () => {
         created_at: getNow().toDate(),
         type: 'text poll',
         user: {
-          uuid: userId,
+          uuid: user.uuid,
           name: 'test',
           profile_pic: 'test-url',
         },
@@ -307,7 +311,7 @@ describe('PostsService', () => {
       postRepo.getAllPosts = jest.fn().mockResolvedValueOnce(postsInDB);
 
       // actions
-      const result = await service.getAllPosts(userId);
+      const result = await service.getAllPosts(user);
 
       // assertions
       expect(result).toEqual(expectedPosts);
@@ -315,7 +319,11 @@ describe('PostsService', () => {
 
     it('should return only the posts with ready = true', async () => {
       // data
-      const userId = 'user1';
+      const user = {
+        uuid: 'user-id',
+        name: 'test',
+        profile_pic: 'test-url',
+      } as User;
       const postInDB = {
         uuid: 'test-post-uuid',
         ready: false,
@@ -324,7 +332,7 @@ describe('PostsService', () => {
         created_at: getNow().toDate(),
         type: 'text poll',
         user: {
-          uuid: userId,
+          uuid: user.uuid,
           name: 'test',
           profile_pic: 'test-url',
         },
@@ -403,7 +411,7 @@ describe('PostsService', () => {
         .mockResolvedValueOnce(postsInDB.filter((post) => post.ready));
 
       // actions
-      const result = await service.getAllPosts(userId);
+      const result = await service.getAllPosts(user);
 
       // assertions
       expect(result).toEqual(expectedPosts);

--- a/src/posts/posts.service.spec.ts
+++ b/src/posts/posts.service.spec.ts
@@ -1120,16 +1120,16 @@ describe('PostsService', () => {
   describe('deletePost', () => {
     it('should return undefined', () => {
       // data
-      const userId = 'test-user-id';
+      const user = { uuid: 'user-uuid' } as User;
       const postId = 'test-post-id';
-      const foundPost = { id: 1, user: { uuid: userId } };
+      const foundPost = { id: 1, user: { uuid: user.uuid } };
 
       //mocks
       postRepo.getPostById = jest.fn().mockResolvedValueOnce(foundPost);
       postRepo.remove = jest.fn().mockResolvedValueOnce(undefined);
 
       // action
-      const res = service.deletePost(postId, userId);
+      const res = service.deletePost(postId, user);
 
       // assertions
       expect(res).resolves.toBeUndefined();
@@ -1137,16 +1137,16 @@ describe('PostsService', () => {
 
     it('should have getPostById method that is called with post id', async () => {
       // data
-      const userId = 'test-user-id';
+      const user = { uuid: 'user-uuid' } as User;
       const postId = 'test-post-id';
-      const foundPost = { id: 1, user: { uuid: userId } };
+      const foundPost = { id: 1, user: { uuid: user.uuid } };
 
       //mocks
       postRepo.getPostById = jest.fn().mockResolvedValueOnce(foundPost);
       postRepo.remove = jest.fn().mockResolvedValueOnce(undefined);
 
       // action
-      await service.deletePost(postId, userId);
+      await service.deletePost(postId, user);
 
       // assertions
       expect(postRepo.getPostById).toBeCalledWith(postId);
@@ -1154,7 +1154,7 @@ describe('PostsService', () => {
 
     it('should throw error if post is not found', () => {
       // data
-      const userId = '2';
+      const user = { uuid: 'user-uuid' } as User;
       const postId = 'test-post-uuid';
 
       //mocks
@@ -1162,7 +1162,7 @@ describe('PostsService', () => {
       postRepo.remove = jest.fn().mockResolvedValueOnce(undefined);
 
       // action
-      const res = service.deletePost(postId, userId);
+      const res = service.deletePost(postId, user);
 
       // assertions
       expect(res).rejects.toThrowError(
@@ -1172,7 +1172,7 @@ describe('PostsService', () => {
 
     it('should throw error if user is not owner of post', () => {
       // data
-      const userId = 'user-owns-post';
+      const user = { uuid: 'user-uuid' } as User;
       const postId = 'test-post-uuid';
       const foundPost = { id: 1, user: { uuid: 'user-dont-own-post' } };
 
@@ -1181,7 +1181,7 @@ describe('PostsService', () => {
       postRepo.remove = jest.fn().mockResolvedValueOnce(undefined);
 
       // action
-      const res = service.deletePost(postId, userId);
+      const res = service.deletePost(postId, user);
 
       // assertions
       expect(res).rejects.toThrowError(
@@ -1191,16 +1191,16 @@ describe('PostsService', () => {
 
     it('should call postRepository.remove with the found post', async () => {
       // data
-      const userId = 'test-user-uuid';
+      const user = { uuid: 'user-uuid' } as User;
       const postId = 'test-post-uuid';
-      const foundPost = { id: 1, user: { uuid: userId } };
+      const foundPost = { id: 1, user: { uuid: user.uuid } };
 
       //mocks
       postRepo.getPostById = jest.fn().mockResolvedValueOnce(foundPost);
       postRepo.remove = jest.fn().mockResolvedValueOnce(undefined);
 
       // action
-      await service.deletePost(postId, userId);
+      await service.deletePost(postId, user);
 
       // assertions
       expect(postRepo.remove).toBeCalledWith(foundPost);

--- a/src/posts/posts.service.spec.ts
+++ b/src/posts/posts.service.spec.ts
@@ -14,6 +14,7 @@ import {
 import { UserRepository } from '../users/entities/user.repository';
 import { Post } from './interfaces/getPosts.interface';
 import { getNow } from '../shared/utils/datetime';
+import { User } from '../users/entities/user.entity';
 
 describe('PostsService', () => {
   let service: PostsService;
@@ -187,80 +188,23 @@ describe('PostsService', () => {
         is_hidden: false,
         media_count: 3,
       };
-      const userId = 'test-user-uuid';
 
       const user = {
         uuid: 'test-user-uuid',
         name: 'test-name',
         profile_pic: 'test-picture-url',
-      };
+      } as User;
 
       // mocks
       postRepo.createPost = jest
         .fn()
         .mockResolvedValueOnce({ uuid: 'created-post-uuid' });
 
-      userRepo.findOne = jest.fn().mockResolvedValue(user);
-
       // action
-      const data = service.createPost(dto, userId);
+      const data = service.createPost(dto, user);
 
       // assertions
       expect(data).resolves.toEqual({ id: 'created-post-uuid' });
-    });
-
-    it('should call userRepo.findOne with the appropriate parameters', async () => {
-      // data
-      const dto: PostCreationDto = {
-        type: 'text_poll',
-        caption: 'test caption',
-        is_hidden: false,
-        media_count: 3,
-      };
-      const userId = 'test-user-uuid';
-
-      const user = {
-        uuid: 'test-user-uuid',
-        name: 'test-name',
-        profile_pic: 'test-picture-url',
-      };
-
-      // mocks
-      postRepo.createPost = jest
-        .fn()
-        .mockResolvedValueOnce({ uuid: 'created-post-uuid' });
-
-      userRepo.findOne = jest.fn().mockResolvedValue(user);
-
-      // action
-      await service.createPost(dto, userId);
-
-      // assertions
-      expect(userRepo.findOne).toBeCalledWith({ where: { uuid: userId } });
-      expect(userRepo.findOne).toBeCalledTimes(1);
-    });
-
-    it('should thorw error if user not found', async () => {
-      // data
-      const dto: PostCreationDto = {
-        type: 'text_poll',
-        caption: 'test caption',
-        is_hidden: false,
-        media_count: 3,
-      };
-      const userId = 'test-user-uuid';
-
-      // mocks
-      postRepo.createPost = jest
-        .fn()
-        .mockResolvedValueOnce({ uuid: 'created-post-uuid' });
-
-      userRepo.findOne = jest.fn().mockResolvedValue(undefined);
-
-      // assertions
-      expect(service.createPost(dto, userId)).rejects.toThrowError(
-        new NotFoundException(`User with id: ${userId} not found`),
-      );
     });
 
     it('should call postRepo.createPost with the appropriate parameters', async () => {
@@ -271,23 +215,20 @@ describe('PostsService', () => {
         is_hidden: false,
         media_count: 3,
       };
-      const userId = 'test-user-uuid';
-
       const user = {
         uuid: 'test-user-uuid',
         name: 'test-name',
         profile_pic: 'test-picture-url',
-      };
+      } as User;
 
       // mocks
       postRepo.createPost = jest
         .fn()
         .mockResolvedValueOnce({ uuid: 'created-post-uuid' });
 
-      userRepo.findOne = jest.fn().mockResolvedValue(user);
 
       // action
-      await service.createPost(dto, userId);
+      await service.createPost(dto, user);
 
       // assertions
       expect(postRepo.createPost).toBeCalledWith(dto, user);

--- a/src/posts/posts.service.spec.ts
+++ b/src/posts/posts.service.spec.ts
@@ -55,8 +55,14 @@ describe('PostsService', () => {
     it('should return the ids of the created groups & options', async () => {
       // data
       const postId = 'test post id';
-      const userId = 'test-user-uuid';
-      const foundPost = { id: 1, user: { uuid: userId } };
+
+      const user = {
+        uuid: 'test-user-uuid',
+        name: 'test-name',
+        profile_pic: 'test-picture-url',
+      } as User;
+
+      const foundPost = { id: 1, user: { uuid: user.uuid } };
       const dto: OptionsGroupCreationDto = {
         groups: [
           {
@@ -97,7 +103,7 @@ describe('PostsService', () => {
         ]);
 
       // action
-      const data = await service.createOptionGroup(postId, dto, userId);
+      const data = await service.createOptionGroup(postId, dto, user);
 
       // assertions
       expect(data).toEqual(createdOptionsGroups);
@@ -106,7 +112,13 @@ describe('PostsService', () => {
     it('should throw error if post not found', async () => {
       // data
       const postId = 'test post id';
-      const userId = '3';
+      
+      const user = {
+        uuid: 'test-user-uuid',
+        name: 'test-name',
+        profile_pic: 'test-picture-url',
+      } as User;
+
       const dto: OptionsGroupCreationDto = {
         groups: [
           {
@@ -132,7 +144,7 @@ describe('PostsService', () => {
         ]);
 
       // action
-      const data = service.createOptionGroup(postId, dto, userId);
+      const data = service.createOptionGroup(postId, dto, user);
 
       // assertions
       expect(data).rejects.toThrowError(
@@ -143,7 +155,13 @@ describe('PostsService', () => {
     it('should throw error if user is not post owner', async () => {
       // data
       const postId = 'test post id';
-      const userId = 'user-owns-post';
+
+      const user = {
+        uuid: 'test-user-uuid',
+        name: 'test-name',
+        profile_pic: 'test-picture-url',
+      } as User;
+
       const foundPost = { id: 1, user: { uuid: 'user-dont-own-post' } };
       const dto: OptionsGroupCreationDto = {
         groups: [
@@ -170,7 +188,7 @@ describe('PostsService', () => {
         ]);
 
       // action
-      const data = service.createOptionGroup(postId, dto, userId);
+      const data = service.createOptionGroup(postId, dto, user);
 
       // assertions
       expect(data).rejects.toThrowError(

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -22,6 +22,7 @@ import {
 import { isUserAuthorized } from '../shared/authorization/userAuthorization';
 import { LockedException } from '../shared/exceptions/locked.exception';
 import { UserRepository } from '../users/entities/user.repository';
+import { User } from '../users/entities/user.entity';
 @Injectable()
 export class PostsService {
   constructor(
@@ -165,16 +166,8 @@ export class PostsService {
 
   async createPost(
     postCreationDto: PostCreationDto,
-    userId: string,
+    user: User,
   ): Promise<PostCreationInterface> {
-    // get user to add post to it
-    const user = await this.userRepository.findOne({ where: { uuid: userId } });
-
-    // Check whether user exists
-    if (!user) {
-      throw new NotFoundException(`User with id: ${userId} not found`);
-    }
-
     // create the post
     const createdPost = await this.postRepository.createPost(
       postCreationDto,

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -176,7 +176,7 @@ export class PostsService {
     return { id: createdPost.uuid };
   }
 
-  async flagPost(postId: string, flag: boolean, userId: string): Promise<void> {
+  async flagPost(postId: string, flag: boolean, user: User): Promise<void> {
     // get post
     const post = await this.postRepository.getPostById(postId);
 
@@ -186,7 +186,7 @@ export class PostsService {
     }
 
     // Allw only post owner to continue
-    if (!isUserAuthorized(post, userId)) {
+    if (!isUserAuthorized(post, user.uuid)) {
       throw new UnauthorizedException('Unauthorized');
     }
 

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -257,7 +257,7 @@ export class PostsService {
     return response;
   }
 
-  async getAllPosts(userId: string): Promise<Posts> {
+  async getAllPosts(user: User): Promise<Posts> {
     // get all posts from DB
     const currentPosts = await this.postRepository.getAllPosts();
 
@@ -265,7 +265,7 @@ export class PostsService {
       postsCount: currentPosts.length,
       // return all posts after modifiying each one as found in openAPI
       posts: currentPosts.map((post) => {
-        return this.handlePostFeatures(post, userId);
+        return this.handlePostFeatures(post, user.uuid);
       }),
     };
   }

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -193,7 +193,7 @@ export class PostsService {
     await this.postRepository.flagPostCreation(flag, post);
   }
 
-  async deletePost(postid: string, userId: string): Promise<void> {
+  async deletePost(postid: string, user: User): Promise<void> {
     // get post
     const post = await this.postRepository.getPostById(postid);
 
@@ -203,7 +203,7 @@ export class PostsService {
     }
 
     // Check if current user is the owner of the post
-    if (!isUserAuthorized(post, userId)) {
+    if (!isUserAuthorized(post, user.uuid)) {
       throw new UnauthorizedException('Unauthorized');
     }
 

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -213,7 +213,7 @@ export class PostsService {
   async createOptionGroup(
     postid: string,
     groupsCreationDto: OptionsGroupCreationDto,
-    userId: string,
+    user: User,
   ): Promise<OptionsGroups> {
     const response: OptionsGroups = { groups: [] };
 
@@ -226,7 +226,7 @@ export class PostsService {
     }
 
     // Allw only post owner to continue
-    if (!isUserAuthorized(post, userId)) {
+    if (!isUserAuthorized(post, user.uuid)) {
       throw new UnauthorizedException('Unauthorized');
     }
 

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -270,7 +270,7 @@ export class PostsService {
     };
   }
 
-  async getSinglePost(postId: string, userId: string): Promise<Post> {
+  async getSinglePost(postId: string, user: User): Promise<Post> {
     const post = await this.postRepository.getDetailedPostById(postId);
     // check whether post is found
     if (!post) throw new NotFoundException(`Post with id: ${postId} not found`);
@@ -282,6 +282,6 @@ export class PostsService {
       );
     }
 
-    return this.handlePostFeatures(post, userId);
+    return this.handlePostFeatures(post, user.uuid);
   }
 }

--- a/src/shared/Guards/firebase-auth.guard.ts
+++ b/src/shared/Guards/firebase-auth.guard.ts
@@ -27,6 +27,11 @@ export class FirebaseAuthGuard extends AuthGuard('firebase-jwt') {
       let foundUser;
       const url = context.getArgByIndex(0).url;
 
+      // if firebase auth in strategy validate method throws an error
+      if (err) {
+        throw new UnauthorizedException(err.message);
+      }
+
       if (url === '/api/users/register') {
         foundUser = await this.userRepo.createUser(user);
       } else {

--- a/src/shared/interfaces/expressRequest.ts
+++ b/src/shared/interfaces/expressRequest.ts
@@ -1,0 +1,6 @@
+import { Request } from 'express';
+import { User } from '../../users/entities/user.entity';
+
+export interface ExtendedRequest extends Request {
+  user: User;
+}

--- a/src/votes/votes.controller.spec.ts
+++ b/src/votes/votes.controller.spec.ts
@@ -1,4 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { ExtendedRequest } from 'src/shared/interfaces/expressRequest';
 import { VotesController } from './votes.controller';
 import { VotesService } from './votes.service';
 
@@ -26,13 +27,23 @@ describe('VotesController', () => {
   });
 
   describe('addVote', () => {
+    // data
     const params = { optionid: 'uuid' };
+    const req = {
+      user: { uuid: 'user-uuid' },
+    } as ExtendedRequest;
     it('should call service function with optionId', async () => {
-      controller.addVote(params, { Authorization: '3' });
-      expect(mockService.addVote).toBeCalledWith(params.optionid, '3');
+      // actions
+      controller.addVote(params, req);
+
+      // assertions
+      expect(mockService.addVote).toBeCalledWith(params.optionid, req.user);
     });
     it('should return whatever service method returns', () => {
-      const res = controller.addVote(params, { Authorization: '3' });
+      // actions
+      const res = controller.addVote(params, req);
+
+      // assertions
       expect(res).resolves.toEqual(['options']);
     });
   });

--- a/src/votes/votes.controller.ts
+++ b/src/votes/votes.controller.ts
@@ -1,10 +1,18 @@
-import { Controller, Param, Put, UseFilters, Headers } from '@nestjs/common';
+import {
+  Controller,
+  Param,
+  Put,
+  UseFilters,
+  Headers,
+  Request,
+} from '@nestjs/common';
 import { OptionIdParam } from '../shared/validations/uuid.validator';
 import { VotesService } from './votes.service';
 import { OptionsVotes } from './interfaces/optionsVotes.interface';
 import { ValidationExceptionFilter } from '../shared/exception-filters/validation-exception.filter';
 import * as winston from 'winston';
 import { winstonLoggerOptions } from '../logging/winston.options';
+import { ExtendedRequest } from 'src/shared/interfaces/expressRequest';
 
 @Controller('votes')
 @UseFilters(
@@ -16,9 +24,8 @@ export class VotesController {
   @Put('/:optionid')
   addVote(
     @Param() params: OptionIdParam,
-    @Headers() headers: { Authorization: string },
+    @Request() req: ExtendedRequest,
   ): Promise<OptionsVotes[]> {
-    const userId = headers.Authorization;
-    return this.votesService.addVote(params.optionid, userId);
+    return this.votesService.addVote(params.optionid, req.user);
   }
 }

--- a/src/votes/votes.service.ts
+++ b/src/votes/votes.service.ts
@@ -9,6 +9,7 @@ import { OptionRepository } from '../posts/entities/option.repository';
 import { VoteRepository } from './entities/votes.repository';
 import { OptionsVotes } from './interfaces/optionsVotes.interface';
 import { UserRepository } from '../users/entities/user.repository';
+import { User } from '../users/entities/user.entity';
 
 @Injectable()
 export class VotesService {
@@ -17,7 +18,7 @@ export class VotesService {
     private optionRepository: OptionRepository,
     private userRepository: UserRepository,
   ) {}
-  async addVote(optionId: string, userId: string): Promise<OptionsVotes[]> {
+  async addVote(optionId: string, user: User): Promise<OptionsVotes[]> {
     // get the option with relation to vote, group & post
     let option = await this.optionRepository.findDetailedOptionById(optionId);
 
@@ -33,14 +34,14 @@ export class VotesService {
     }
 
     // prevent post owner from voting
-    if (option.optionsGroup.post.user.uuid == userId) {
+    if (option.optionsGroup.post.user.uuid == user.uuid) {
       throw new BadRequestException(`You cannot vote on your own post`);
     }
 
     // prevent user from voting twice on any option inside the group
     let isUserVoted = false;
     option.optionsGroup.options.forEach((option) => {
-      isUserVoted = option.votes.some((vote) => vote.user.uuid === userId);
+      isUserVoted = option.votes.some((vote) => vote.user.uuid === user.uuid);
       if (isUserVoted) {
         throw new ConflictException(
           `User has already voted for option with id:${option.uuid}`,
@@ -51,9 +52,6 @@ export class VotesService {
     // delete votes from option
     // as it cuase error when adding option to a vote in voteRepository.addVote
     delete option.votes;
-
-    // get user so we can relate it when adding a vote
-    const user = await this.userRepository.findOne({ where: { uuid: userId } });
 
     // add vote
     await this.voteRepository.addVote(option, user);


### PR DESCRIPTION
Closes #136
- Update the methods in all controllers and services to receive `user` as argument from `req` instead of `userId` from `headers`
- Remove unnecessary finding user from any service 
- Update tests accordingly 