### PR TITLE
Introduce rabbitmq

### DIFF
--- a/.github/workflows/m3ntorship-dev_posts_dev.yml
+++ b/.github/workflows/m3ntorship-dev_posts_dev.yml
@@ -18,12 +18,13 @@ env:
   M3_DOCKER_FILE: Dockerfile
   M3_IMAGE: m3ntorshipci/posts-service
   M3_HOST_NAME: m3ntorship.net
-  M3_POSTS_DB_URL: ${{secrets.ELEPHANTSQL_URL}}
-  M3_RABBITMQ_URL: ${{secrets.RABBITMQ_URL}}
-  M3_BROKER_QUEUE_PATTERN: added_media_data
+  # M3_POSTS_DB_URL: ${{secrets.ELEPHANTSQL_URL}}
+  # M3_RABBITMQ_URL: ${{secrets.RABBITMQ_URL}}
   M3_SERVICE_OPENAPI_SPECIFICATION: https://raw.githubusercontent.com/m3ntorship/pickify-v2-posts/development/openAPI/post.openAPI.yml
   M3_NODE_ENV: production
-  M3_MEDIA_QUEUE: media_queue_dev
+  # rabbitMQ
+  M3_MEDIA_QUEUE: lazy-queue-pickify-media-dev
+  M3_BROKER_QUEUE_PATTERN: added_media_data
   
   # db
   M3_DB_INSTANCES: 1

--- a/deploy/apply/deployment.yml
+++ b/deploy/apply/deployment.yml
@@ -19,6 +19,7 @@ spec:
         - name: "{{{M3_COMPONENT}}}-main-container"
           image: "{{{M3_IMAGE}}}:{{{M3_VERSION}}}"
           env:
+            # Database variables
             - name: APP_DB_USERNAME
               valueFrom:
                 secretKeyRef:
@@ -31,17 +32,29 @@ spec:
                   key: password
             - name: APP_DB_HOST
               value: "{{{M3_PROJECT}}}-{{{M3_COMPONENT}}}-db.{{{M3_NAMESPACE}}}.svc.cluster.local"
-
-            - name: DB_URL
-              value: {{{M3_POSTS_DB_URL}}}
-            - name: NODE_ENV
-              value: {{{M3_NODE_ENV}}}
-            - name: RABBITMQ_URL
-              value: {{{M3_RABBITMQ_URL}}}
+            # rabbitMQ variables
+            - name: RABBITMQ_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: "rabbitmq-dev-default-user"
+                  key: password
+            - name: RABBITMQ_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: "rabbitmq-dev-default-user"
+                  key: username
+            - name: RABBITMQ_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: "rabbitmq-dev-default-user"
+                  key: host
             - name: MEDIA_QUEUE
               value: {{{M3_MEDIA_QUEUE}}}    
             - name: BROKER_QUEUE_PATTERN
               value: {{{M3_BROKER_QUEUE_PATTERN}}}
+            # general variables
+            - name: NODE_ENV
+              value: {{{M3_NODE_ENV}}}
           ports:
             - name: web
               containerPort: 3000

--- a/deploy/apply/queues.yml
+++ b/deploy/apply/queues.yml
@@ -1,0 +1,40 @@
+# For more information on lazy queues, see: https://www.rabbitmq.com/lazy-queues.html.
+# We recommmend configuring queues through policies to manage them in groups and be able to update queue configurations later on.
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Policy
+metadata:
+  name: lazy-queue-policy
+  namespace: default #it has to be default as the centeralized cluster is deployed in default namesapce
+spec:
+  name: lazy-queue-policy
+  vhost: 'pickify-dev'
+  pattern: '^lazy-queue-' # matches any queue begins with "lazy-queue-"
+  applyTo: 'queues'
+  definition:
+    queue-mode: lazy
+  rabbitmqClusterReference:
+    name: rabbitmq-dev
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Queue
+metadata:
+  name: lazy-queue-pickify-media-dev
+  namespace: default #it has to be default as the centeralized cluster is deployed in default namesapce
+spec:
+  name: lazy-queue-pickify-media-dev # matches the pattern "^lazy-queue$" set in lazy-queue-policy
+  vhost: 'pickify-dev'
+  autoDelete: false
+  durable: true
+  rabbitmqClusterReference:
+    name: rabbitmq-dev
+---
+apiVersion: rabbitmq.com/v1beta1
+kind: Vhost
+metadata:
+  name: pickify-dev # name of this custom resource
+  namespace: default #it has to be default as the centeralized cluster is deployed in default namesapce
+spec:
+  name: pickify-dev # name of the vhost
+  rabbitmqClusterReference:
+    name: rabbitmq-dev

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -1,6 +1,6 @@
 export default () => ({
   port: parseInt(process.env.PORT, 10) || 3000,
-  rabbitURL: process.env.RABBITMQ_URL,
+  rabbitURL: `amqp://${process.env.RABBITMQ_USERNAME}:${process.env.RABBITMQ_PASS}@${process.env.RABBITMQ_HOST}/${process.env.RABBITMQ_USERNAME}`,
   rabbitMediaQueue: process.env.MEDIA_QUEUE,
   queuePattern: process.env.BROKER_QUEUE_PATTERN,
   clients: {


### PR DESCRIPTION
Closes #158 
### In this PR we migrate to rabbitMQ hosted on k8s cluster. 
- Queue service k8s configuration file was added
- Updated the environment variables to use k8s queue credentials secrets